### PR TITLE
refactor(firehose-protos): reorganize ethereum v1 module

### DIFF
--- a/crates/firehose-protos/src/ethereum_v2/eth_block.rs
+++ b/crates/firehose-protos/src/ethereum_v2/eth_block.rs
@@ -1,19 +1,13 @@
-//! Firehose Ethereum-related data structures and operations.
-//! See the protobuffer definitions section of the README for more information.
-//!
+use super::Block;
 use alloy_primitives::{Address, Bloom, FixedBytes, Uint};
 use ethportal_api::types::execution::header::Header;
 use prost::Message;
 use prost_wkt_types::Any;
-use reth_primitives::TxType;
-use transaction_trace::Type;
 
 use crate::{
     error::ProtosError,
     firehose::v2::{Response, SingleBlockResponse},
 };
-
-tonic::include_proto!("sf.ethereum.r#type.v2");
 
 impl TryFrom<&Block> for Header {
     type Error = ProtosError;
@@ -94,28 +88,6 @@ impl TryFrom<&Block> for Header {
     }
 }
 
-impl From<Type> for TxType {
-    fn from(tx_type: Type) -> Self {
-        use TxType::*;
-        use Type::*;
-
-        match tx_type {
-            TrxTypeLegacy => Legacy,
-            TrxTypeAccessList => Eip2930,
-            TrxTypeDynamicFee => Eip1559,
-            TrxTypeBlob => Eip4844,
-            TrxTypeArbitrumDeposit => unimplemented!(),
-            TrxTypeArbitrumUnsigned => unimplemented!(),
-            TrxTypeArbitrumContract => unimplemented!(),
-            TrxTypeArbitrumRetry => unimplemented!(),
-            TrxTypeArbitrumSubmitRetryable => unimplemented!(),
-            TrxTypeArbitrumInternal => unimplemented!(),
-            TrxTypeArbitrumLegacy => unimplemented!(),
-            TrxTypeOptimismDeposit => unimplemented!(),
-        }
-    }
-}
-
 fn decode_block<M>(response: M) -> Result<Block, ProtosError>
 where
     M: MessageWithBlock,
@@ -159,6 +131,10 @@ impl TryFrom<Response> for Block {
 
 #[cfg(test)]
 mod tests {
+    use ethportal_api::Header;
+
+    use crate::ethereum_v2::BlockHeader;
+
     use super::*;
 
     #[test]

--- a/crates/firehose-protos/src/ethereum_v2/mod.rs
+++ b/crates/firehose-protos/src/ethereum_v2/mod.rs
@@ -1,0 +1,8 @@
+//! Firehose Ethereum-related data structures and operations.
+//! See the protobuffer definitions section of the README for more information.
+//!
+
+pub mod eth_block;
+pub mod transaction;
+
+tonic::include_proto!("sf.ethereum.r#type.v2");

--- a/crates/firehose-protos/src/ethereum_v2/transaction.rs
+++ b/crates/firehose-protos/src/ethereum_v2/transaction.rs
@@ -1,0 +1,25 @@
+use reth_primitives::TxType;
+
+use super::transaction_trace::Type;
+
+impl From<Type> for TxType {
+    fn from(tx_type: Type) -> Self {
+        use TxType::*;
+        use Type::*;
+
+        match tx_type {
+            TrxTypeLegacy => Legacy,
+            TrxTypeAccessList => Eip2930,
+            TrxTypeDynamicFee => Eip1559,
+            TrxTypeBlob => Eip4844,
+            TrxTypeArbitrumDeposit => unimplemented!(),
+            TrxTypeArbitrumUnsigned => unimplemented!(),
+            TrxTypeArbitrumContract => unimplemented!(),
+            TrxTypeArbitrumRetry => unimplemented!(),
+            TrxTypeArbitrumSubmitRetryable => unimplemented!(),
+            TrxTypeArbitrumInternal => unimplemented!(),
+            TrxTypeArbitrumLegacy => unimplemented!(),
+            TrxTypeOptimismDeposit => unimplemented!(),
+        }
+    }
+}


### PR DESCRIPTION
In order to [review testing of public functions in `flat-files-decoder`](https://linear.app/semiotic/issue/BACK-67/test-public-functions-of-flat-files-decoder), we want to [remove methods that could be implemented more readably and testably as conversions on the protobuffer types](https://linear.app/semiotic/issue/BACK-113/convert-methods-converting-firehose-protos-types-to-methods-on-those). These are all `ethereum_v1` protobuffer types so this PR clears the way for that work by [creating a clearer `ethereum_v1` module structure](https://linear.app/semiotic/issue/BACK-114/firehose-protos-create-ethereum-v1-module).