### PR TITLE
Pedro/back 153 move changes to firehose protos into another pr

### DIFF
--- a/crates/firehose-protos/src/ethereum_v2/eth_block.rs
+++ b/crates/firehose-protos/src/ethereum_v2/eth_block.rs
@@ -268,7 +268,7 @@ impl Block {
 }
 
 pub struct FullReceipt {
-    pub receipt: ReceiptWithBloom,
+    receipt: ReceiptWithBloom,
     state_root: Vec<u8>,
 }
 
@@ -336,6 +336,11 @@ impl FullReceipt {
     /// [`ReceiptWithBloom`] `encode_inner` method.
     fn encode_byzantium_and_later_receipt(&self, encoded: &mut Vec<u8>) {
         self.receipt.encode_inner(encoded, false);
+    }
+
+    /// Returns a reference to the [`ReceiptWithBloom`] for this [`FullReceipt`]
+    pub fn get_receipt_wb(&self) -> &ReceiptWithBloom {
+        &self.receipt
     }
 
     /// Encodes receipt header using [RLP serialization](https://ethereum.org/en/developers/docs/data-structures-and-encoding/rlp)


### PR DESCRIPTION
# [BACK-153](https://linear.app/semiotic/issue/BACK-153/move-changes-to-firehose-protos-into-another-pr)

These changes are necessary for this PR:
https://github.com/semiotic-ai/veemon/pull/50/files

It makes the `full_receipts` public.
Another approach would be to make another function called `full_receipts_with_bloom`  that actually gives the `Vec<ReceiptWithBloom>` avoiding the necessity of making `FullReceipt` a public struct. Should I implement this `full_receipts_with_bloom` instead?