### PR TITLE
chore: add vee as unified interface for veemon

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -975,9 +975,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.1"
+version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fd9de9f2205d5ef3fd67e685b0df337994ddd4495e2a28d185500d0e1edfea47"
+checksum = "f34d93e62b03caf570cccc334cbc6c2fceca82f39211051345108adcba3eebdc"
 dependencies = [
  "jobserver",
  "libc",
@@ -1882,7 +1882,7 @@ checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 [[package]]
 name = "firehose-client"
 version = "0.1.1"
-source = "git+https://github.com/semiotic-ai/firehose-client.git?branch=main#035980e6817eee5c3d40678dd0e1bfa6bb8da594"
+source = "git+https://github.com/semiotic-ai/firehose-client.git?branch=main#d10f89a3dc2c8a3c76ce2dc3a4a7f81e13eeac24"
 dependencies = [
  "dotenvy",
  "firehose-rs",
@@ -1939,7 +1939,7 @@ dependencies = [
 [[package]]
 name = "firehose-rs"
 version = "0.1.0"
-source = "git+https://github.com/semiotic-ai/firehose-rs.git?branch=main#be85002a5a1d3d298704b0465d531d14cff51caf"
+source = "git+https://github.com/semiotic-ai/firehose-rs.git?branch=main#55851f4e89ba4191c0dab83b3391d9c3b5bbbcf1"
 dependencies = [
  "prost",
  "prost-build",
@@ -3097,9 +3097,9 @@ checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
 
 [[package]]
 name = "libc"
-version = "0.2.166"
+version = "0.2.167"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2ccc108bbc0b1331bd061864e7cd823c0cab660bbe6970e66e2c0614decde36"
+checksum = "09d6582e104315a817dff97f75133544b2e094ee22447d2acf4a74e189ba06fc"
 
 [[package]]
 name = "libgit2-sys"
@@ -5697,6 +5697,15 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "vee"
+version = "0.1.0"
+dependencies = [
+ "firehose-protos",
+ "flat-files-decoder",
+ "header-accumulator",
+]
 
 [[package]]
 name = "version_check"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,10 @@ bincode = "1.3.3"
 clap = { version = "4.4.10", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
 ethportal-api = { git = "https://github.com/ethereum/trin.git", version = "0.2.2", tag = "v0.1.0-alpha.51" }
+firehose-protos = { path = "crates/firehose-protos" }
 firehose-rs = { git = "https://github.com/semiotic-ai/firehose-rs.git", branch = "main" }
+flat-files-decoder = { path = "crates/flat-files-decoder" }
+header-accumulator = { path = "crates/header-accumulator" }
 hex = "0.4.3"
 log = "0.4.20"
 primitive-types = "0.12.2"

--- a/crates/firehose-protos-examples/Cargo.toml
+++ b/crates/firehose-protos-examples/Cargo.toml
@@ -6,5 +6,5 @@ edition = "2021"
 [dev-dependencies]
 alloy-primitives.workspace = true
 firehose-client = { git = "https://github.com/semiotic-ai/firehose-client.git", branch = "main" }
-firehose-protos = { path = "../firehose-protos" }
+firehose-protos.workspace = true
 tokio.workspace = true

--- a/crates/flat-files-decoder/Cargo.toml
+++ b/crates/flat-files-decoder/Cargo.toml
@@ -12,7 +12,7 @@ alloy-primitives.workspace = true
 alloy-consensus.workspace = true
 alloy-eip2930.workspace = true
 bincode.workspace = true
-firehose-protos = { path = "../firehose-protos" }
+firehose-protos.workspace = true
 prost.workspace = true
 reth-primitives.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/header-accumulator/Cargo.toml
+++ b/crates/header-accumulator/Cargo.toml
@@ -10,7 +10,7 @@ alloy-primitives.workspace = true
 base64.workspace = true
 clap.workspace = true
 ethportal-api.workspace = true
-firehose-protos = { path = "../firehose-protos" }
+firehose-protos.workspace = true
 log.workspace = true
 primitive-types.workspace = true
 rlp.workspace = true
@@ -21,5 +21,5 @@ trin-validation.workspace = true
 thiserror.workspace = true
 
 [dev-dependencies]
-flat-files-decoder = { path = "../flat-files-decoder" }
+flat-files-decoder.workspace = true
 tempfile.workspace = true

--- a/crates/vee/Cargo.toml
+++ b/crates/vee/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "vee"
+version = "0.1.0"
+edition = "2021"
+
+[lib]
+path = "src/lib.rs"
+name = "vee"
+
+[dependencies]
+firehose-protos.workspace = true
+flat-files-decoder.workspace = true
+header-accumulator.workspace = true

--- a/crates/vee/README.md
+++ b/crates/vee/README.md
@@ -1,0 +1,9 @@
+# Vee
+
+Verifiable Extraction for Blockchain.
+
+## Re-exports
+
+- [firehose-protos](./crates/firehose-protos/README.md)
+- [flat-files-decoder](./crates/flat-files-decoder/README.md)
+- [header-accumulator](./crates/header-accumulator/README.md)

--- a/crates/vee/src/lib.rs
+++ b/crates/vee/src/lib.rs
@@ -1,0 +1,15 @@
+// Copyright 2024-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+#![doc = include_str!("../README.md")]
+
+// 🚀✨ Main Re-exports ✨🚀
+
+#[doc(inline)]
+pub use firehose_protos as protos;
+
+#[doc(inline)]
+pub use flat_files_decoder as decoder;
+
+#[doc(inline)]
+pub use header_accumulator as accumulator;


### PR DESCRIPTION
This is the first iteration of a number of rich ways we can build on this pattern. Here we get access to all public types and methods via `vee::accumulator`, `vee::decoder`, and `vee::protos`.