### PR TITLE
chore: allows deprecated to remove warnings while it is not upgraded …

### DIFF
--- a/crates/firehose-protos/src/ethereum_v2/transaction.rs
+++ b/crates/firehose-protos/src/ethereum_v2/transaction.rs
@@ -1,3 +1,4 @@
+#![allow(deprecated)]
 // Copyright 2024-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 


### PR DESCRIPTION
allows deprecated to remove warnings while it is not upgraded to use alloy instead of reth