### PR TITLE
fix: specification of git dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1923,7 +1923,7 @@ dependencies = [
 [[package]]
 name = "ethportal-api"
 version = "0.4.1"
-source = "git+https://github.com/ethereum/trin.git#81045efc988d3a9499d8a1cfd972b3e65372b347"
+source = "git+https://github.com/ethereum/trin.git?rev=81045ef#81045efc988d3a9499d8a1cfd972b3e65372b347"
 dependencies = [
  "alloy",
  "alloy-rlp",
@@ -5332,7 +5332,7 @@ dependencies = [
 [[package]]
 name = "trin-validation"
 version = "0.1.0"
-source = "git+https://github.com/ethereum/trin.git#81045efc988d3a9499d8a1cfd972b3e65372b347"
+source = "git+https://github.com/ethereum/trin.git?rev=81045ef#81045efc988d3a9499d8a1cfd972b3e65372b347"
 dependencies = [
  "alloy",
  "anyhow",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.22.1"
 bincode = "1.3.3"
 clap = { version = "4.5.23", features = ["derive"] }
 criterion = { version = "0.5.1", features = ["html_reports"] }
-ethportal-api = { git = "https://github.com/ethereum/trin.git", version = "0.4.0" }
+ethportal-api = { git = "https://github.com/ethereum/trin.git", rev = "81045ef" }
 firehose-protos = { path = "crates/firehose-protos" }
 firehose-rs = { git = "https://github.com/semiotic-ai/firehose-rs.git", branch = "main" }
 decoder = { path = "crates/decoder" }
@@ -23,8 +23,8 @@ prost-build = "0.13.4"
 prost-wkt = "0.6.0"
 prost-wkt-types = "0.6.0"
 rand = "0.9.0"
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.1.0", tag = "v1.1.0" }
-reth-trie-common = { git = "https://github.com/paradigmxyz/reth", version = "1.1.0", tag = "v1.1.0" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.0" }
+reth-trie-common = { git = "https://github.com/paradigmxyz/reth", tag = "v1.1.0" }
 rlp = "0.5.2"
 serde = "1.0.216"
 serde_json = "1.0.133"
@@ -36,7 +36,7 @@ tonic-build = "0.12.3"
 tracing = "0.1.41"
 tracing-subscriber = "0.3.19"
 tree_hash = "0.8.0"
-trin-validation = { git = "https://github.com/ethereum/trin.git", version = "0.1.0" }
+trin-validation = { git = "https://github.com/ethereum/trin.git", rev = "81045ef" }
 zstd = "0.13.2"
 
 [profile.dev.build-override]


### PR DESCRIPTION
The use of `version` for git deps does not work as intended, especially when pulling in veemon crates as dependencies elsewhere.

https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#the-role-of-the-version-key