### PR TITLE
fix: export PreMergeAccumulatorProof

### DIFF
--- a/crates/header-accumulator/src/inclusion_proof.rs
+++ b/crates/header-accumulator/src/inclusion_proof.rs
@@ -2,14 +2,12 @@
 // SPDX-License-Identifier: Apache-2.0
 
 use crate::{epoch::MAX_EPOCH_SIZE, errors::EraValidateError, Epoch};
-pub use ethportal_api::Header;
+pub use ethportal_api::{types::execution::header_with_proof::PreMergeAccumulatorProof, Header};
 
 use alloy_primitives::FixedBytes;
 use ethportal_api::types::execution::{
     accumulator::EpochAccumulator,
-    header_with_proof::{
-        BlockHeaderProof, HeaderWithProof as PortalHeaderWithProof, PreMergeAccumulatorProof,
-    },
+    header_with_proof::{BlockHeaderProof, HeaderWithProof as PortalHeaderWithProof},
 };
 use trin_validation::{
     accumulator::PreMergeAccumulator, header_validator::HeaderValidator,


### PR DESCRIPTION
The proof data returned from `generate_inclusion_proof` cannot be used because the fields of `InclusionProof` are private. Since there is `impl From<InclusionProof> for PreMergeAccumulatorProof`, I've opted to just re-export `PreMergeAccumulatorProof`. But it may be more obvious to just make the fields of `InclusionProof` public. 