### PR TITLE
Arbitrum ve

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -627,6 +627,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 
 [[package]]
+name = "arbitrum-ve"
+version = "0.1.0"
+dependencies = [
+ "alloy-primitives",
+ "ethportal-api",
+ "serde",
+ "thiserror 2.0.11",
+]
+
+[[package]]
 name = "ark-ff"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5550,6 +5560,7 @@ checksum = "830b7e5d4d90034032940e4ace0d9a9a057e7a45cd94e6c007832e39edb82f6d"
 name = "vee"
 version = "0.1.1"
 dependencies = [
+ "arbitrum-ve",
  "decoder",
  "firehose-protos",
  "header-accumulator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ tracing-subscriber = "0.3.19"
 tree_hash = "0.8.0"
 trin-validation = { git = "https://github.com/ethereum/trin.git", rev = "81045ef" }
 zstd = "0.13.2"
+arbitrum-ve = { path = "crates/arbitrum-ve" }
 
 [profile.dev.build-override]
 opt-level = 3

--- a/crates/arbitrum-ve/Cargo.toml
+++ b/crates/arbitrum-ve/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "arbitrum-ve"
+version = "0.1.0"
+edition = "2021"
+
+[dependencies]
+serde = { workspace = true, features = ["derive"] }
+ethportal-api.workspace = true
+alloy-primitives.workspace = true
+thiserror.workspace = true

--- a/crates/arbitrum-ve/src/errors.rs
+++ b/crates/arbitrum-ve/src/errors.rs
@@ -1,4 +1,3 @@
-
 /// Arbitrum verification errors
 #[derive(thiserror::Error, Debug)]
 pub enum ArbitrumValidateError {

--- a/crates/arbitrum-ve/src/errors.rs
+++ b/crates/arbitrum-ve/src/errors.rs
@@ -1,0 +1,8 @@
+
+/// Arbitrum verification errors
+#[derive(thiserror::Error, Debug)]
+pub enum ArbitrumValidateError {
+    /// Error verifying OffchainInclusionProof
+    #[error("Error verifying OffchainInclusionProof")]
+    OffchainInclusionProofVerificationFailure,
+}

--- a/crates/arbitrum-ve/src/inclusion_proof.rs
+++ b/crates/arbitrum-ve/src/inclusion_proof.rs
@@ -1,15 +1,17 @@
+// Copyright 2024-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
 
 use crate::errors::ArbitrumValidateError;
 
-use ethportal_api::Header;
 use alloy_primitives::B256;
+use ethportal_api::Header;
 
 /// Off-chain inclusion proof
 #[derive(Debug, Clone)]
 pub struct OffchainInclusionProof {
     /// The Arbitrum block header to prove
     pub target_header: Header,
-   
+
     /// The start block hash from an Arbitrum RBlock
     pub start_block_hash: B256,
 
@@ -35,26 +37,40 @@ pub fn generate_offchain_inclusion_proof(
 }
 
 pub fn verify_offchain_inclusion_proof(
-    proof: &OffchainInclusionProof
+    proof: &OffchainInclusionProof,
 ) -> Result<(), ArbitrumValidateError> {
     // Confirm that the target_header is in the block_header_sequence
-    if !proof.block_header_sequence.iter().any(|header| header == &proof.target_header) {
+    if !proof
+        .block_header_sequence
+        .iter()
+        .any(|header| header == &proof.target_header)
+    {
         return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
     }
 
     // Confirm that the start_block_hash is the hash of the first block in the
-// block_header_sequence
-    if proof.block_header_sequence.first().map(|header| header.hash()) != Some(proof.start_block_hash) {
+    // block_header_sequence
+    if proof
+        .block_header_sequence
+        .first()
+        .map(|header| header.hash())
+        != Some(proof.start_block_hash)
+    {
         return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
     }
 
     // Confirm that the end_block_hash is the hash of the last block in the block_header_sequence
-    if proof.block_header_sequence.last().map(|header| header.hash()) != Some(proof.end_block_hash) {
+    if proof
+        .block_header_sequence
+        .last()
+        .map(|header| header.hash())
+        != Some(proof.end_block_hash)
+    {
         return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
     }
 
     // Confirm that the block_header_sequence is correct by confirming that the parent hash for the
-// current header is the hash of the previous header
+    // current header is the hash of the previous header
     for i in 1..proof.block_header_sequence.len() {
         if proof.block_header_sequence[i].parent_hash != proof.block_header_sequence[i - 1].hash() {
             return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
@@ -63,4 +79,3 @@ pub fn verify_offchain_inclusion_proof(
 
     Ok(())
 }
-

--- a/crates/arbitrum-ve/src/inclusion_proof.rs
+++ b/crates/arbitrum-ve/src/inclusion_proof.rs
@@ -22,6 +22,10 @@ pub struct OffchainInclusionProof {
     pub block_header_sequence: Vec<Header>,
 }
 
+/// The off-chain inclusion proof is relatively trivial. It consists simply of the Arbitrum block
+/// header to be verified `target_header`, the start block hash `start_block_hash` indicated an RBlock, the end block hash `end_block_hash` indicated
+/// in the same RBlock, and all Arbitrum block headers between the start and and block hashes
+/// `block_header_sequence`.
 pub fn generate_offchain_inclusion_proof(
     target_header: Header,
     start_block_hash: B256,
@@ -36,6 +40,9 @@ pub fn generate_offchain_inclusion_proof(
     }
 }
 
+/// Off-chain proof verification is simple. We simply confirm that the target header is inclueded
+/// in the sequence of block headers between the start and end block hashes, then we confirm that
+/// the block header hash sequence from start to end block is correct.
 pub fn verify_offchain_inclusion_proof(
     proof: &OffchainInclusionProof,
 ) -> Result<(), ArbitrumValidateError> {

--- a/crates/arbitrum-ve/src/inclusion_proof.rs
+++ b/crates/arbitrum-ve/src/inclusion_proof.rs
@@ -1,0 +1,66 @@
+
+use crate::errors::ArbitrumValidateError;
+
+use ethportal_api::Header;
+use alloy_primitives::B256;
+
+/// Off-chain inclusion proof
+#[derive(Debug, Clone)]
+pub struct OffchainInclusionProof {
+    /// The Arbitrum block header to prove
+    pub target_header: Header,
+   
+    /// The start block hash from an Arbitrum RBlock
+    pub start_block_hash: B256,
+
+    /// The end block hash from Arbitrum RBlock
+    pub end_block_hash: B256,
+
+    /// The blockheader sequence containing the block
+    pub block_header_sequence: Vec<Header>,
+}
+
+pub fn generate_offchain_inclusion_proof(
+    target_header: Header,
+    start_block_hash: B256,
+    end_block_hash: B256,
+    block_header_sequence: Vec<Header>,
+) -> OffchainInclusionProof {
+    OffchainInclusionProof {
+        target_header,
+        start_block_hash,
+        end_block_hash,
+        block_header_sequence,
+    }
+}
+
+pub fn verify_offchain_inclusion_proof(
+    proof: &OffchainInclusionProof
+) -> Result<(), ArbitrumValidateError> {
+    // Confirm that the target_header is in the block_header_sequence
+    if !proof.block_header_sequence.iter().any(|header| header == &proof.target_header) {
+        return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
+    }
+
+    // Confirm that the start_block_hash is the hash of the first block in the
+// block_header_sequence
+    if proof.block_header_sequence.first().map(|header| header.hash()) != Some(proof.start_block_hash) {
+        return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
+    }
+
+    // Confirm that the end_block_hash is the hash of the last block in the block_header_sequence
+    if proof.block_header_sequence.last().map(|header| header.hash()) != Some(proof.end_block_hash) {
+        return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
+    }
+
+    // Confirm that the block_header_sequence is correct by confirming that the parent hash for the
+// current header is the hash of the previous header
+    for i in 1..proof.block_header_sequence.len() {
+        if proof.block_header_sequence[i].parent_hash != proof.block_header_sequence[i - 1].hash() {
+            return Err(ArbitrumValidateError::OffchainInclusionProofVerificationFailure);
+        }
+    }
+
+    Ok(())
+}
+

--- a/crates/arbitrum-ve/src/lib.rs
+++ b/crates/arbitrum-ve/src/lib.rs
@@ -1,0 +1,6 @@
+mod inclusion_proof;
+mod errors;
+
+pub use inclusion_proof::*;
+pub use errors::*;
+

--- a/crates/arbitrum-ve/src/lib.rs
+++ b/crates/arbitrum-ve/src/lib.rs
@@ -1,6 +1,5 @@
-mod inclusion_proof;
 mod errors;
+mod inclusion_proof;
 
-pub use inclusion_proof::*;
 pub use errors::*;
-
+pub use inclusion_proof::*;

--- a/crates/vee/Cargo.toml
+++ b/crates/vee/Cargo.toml
@@ -11,6 +11,7 @@ name = "vee"
 firehose-protos.workspace = true
 decoder.workspace = true
 header-accumulator.workspace = true
+arbitrum-ve.workspace = true
 
 [dev-dependencies]
 tree_hash.workspace = true

--- a/crates/vee/src/lib.rs
+++ b/crates/vee/src/lib.rs
@@ -18,3 +18,4 @@ pub use header_accumulator as accumulator;
 pub use accumulator::*;
 pub use decoder::*;
 pub use protos::*;
+pub use arbitrum_ve::*;

--- a/crates/vee/src/lib.rs
+++ b/crates/vee/src/lib.rs
@@ -16,6 +16,6 @@ pub use flat_files_decoder as decoder;
 pub use header_accumulator as accumulator;
 
 pub use accumulator::*;
+pub use arbitrum_ve::*;
 pub use decoder::*;
 pub use protos::*;
-pub use arbitrum_ve::*;


### PR DESCRIPTION
This PR adds a module for verifying Arbitrum data. In particular it implements inclusion proofs that can be used to prove that an Arbitrum block was included in the canonical history of the Arbitrum chain. The proof relies on Arbitrum RBlocks which are periodically posted to Ethereum and are assertions by Arbitrum validators about the state of the L2.

Combining the proof in this module with an transaction inclusion proof for the RBlock assertion on Ethereum effectively proves that the block is part of the canonical history of Arbitrum. See this [document](https://www.notion.so/semiotic/Arbitrum-VE-154cff788181808fa011c283578726ae?pvs=4) for more details.