### PR TITLE
feat(firehose-protos): Include use of SF Solana Block protobuf

### DIFF
--- a/crates/firehose-protos/README.md
+++ b/crates/firehose-protos/README.md
@@ -9,6 +9,10 @@ definitions, enabling efficient encoding and decoding of data for Ethereum block
 
 Representation of the tracing of a block in the Ethereum blockchain.
 
+### [`sol_block.proto`](https://github.com/streamingfast/firehose-solana/blob/develop/proto/sf/solana/type/v1/type.proto)
+
+Representation of the tracing of a block in the Solana blockchain.
+
 ### [`bstream.proto`](https://github.com/streamingfast/bstream/blob/develop/proto/sf/bstream/v1/bstream.proto)
 
 `Block` type from the Streamingfast block streaming Handlers library. Lower level building block of dfuse.

--- a/crates/firehose-protos/build.rs
+++ b/crates/firehose-protos/build.rs
@@ -22,7 +22,7 @@ fn main() {
         .file_descriptor_set_path(out_dir.join("descriptors.bin"))
         .compile_protos_with_config(
             config,
-            &["protos/block.proto", "protos/bstream.proto"],
+            &["protos/block.proto", "protos/bstream.proto", "protos/sol_block.proto"],
             &["protos/"],
         )
         .unwrap();

--- a/crates/firehose-protos/build.rs
+++ b/crates/firehose-protos/build.rs
@@ -22,7 +22,11 @@ fn main() {
         .file_descriptor_set_path(out_dir.join("descriptors.bin"))
         .compile_protos_with_config(
             config,
-            &["protos/block.proto", "protos/bstream.proto", "protos/sol_block.proto"],
+            &[
+                "protos/block.proto",
+                "protos/bstream.proto",
+                "protos/sol_block.proto",
+            ],
             &["protos/"],
         )
         .unwrap();

--- a/crates/firehose-protos/protos/sol_block.proto
+++ b/crates/firehose-protos/protos/sol_block.proto
@@ -1,0 +1,156 @@
+syntax = "proto3";
+
+import "google/protobuf/timestamp.proto";
+
+option go_package = "github.com/streamingfast/firehose-solana/pb/sf/solana/type/v1;pbsol";
+
+package sf.solana.type.v1;
+
+// This Block is backwards compatible with solana.storage.ConfirmedBlock.ConfirmedBlock from
+// the Solana Labs repositories.
+message Block {
+    string previous_blockhash = 1;
+    string blockhash = 2;
+    uint64 parent_slot = 3;
+    repeated ConfirmedTransaction transactions = 4;
+    repeated Reward rewards = 5;
+    UnixTimestamp block_time = 6;
+    BlockHeight block_height = 7;
+
+    // StreamingFast additions
+    uint64 slot = 20;
+}
+
+message ConfirmedTransaction {
+    Transaction transaction = 1;
+    TransactionStatusMeta meta = 2;
+}
+
+message Transaction {
+    repeated bytes signatures = 1;
+    Message message = 2;
+}
+
+message Message {
+    MessageHeader header = 1;
+    repeated bytes account_keys = 2;
+    bytes recent_blockhash = 3;
+    // Top-level instructions
+    // T instructions (?)
+    repeated CompiledInstruction instructions = 4;
+    bool versioned = 5;
+    repeated MessageAddressTableLookup address_table_lookups = 6;
+}
+
+message MessageHeader {
+    uint32 num_required_signatures = 1;
+    uint32 num_readonly_signed_accounts = 2;
+    uint32 num_readonly_unsigned_accounts = 3;
+}
+
+message MessageAddressTableLookup {
+    bytes account_key = 1;
+    bytes writable_indexes = 2;
+    bytes readonly_indexes = 3;
+}
+
+message TransactionStatusMeta {
+    TransactionError err = 1;
+    uint64 fee = 2;
+    repeated uint64 pre_balances = 3;
+    repeated uint64 post_balances = 4;
+    // InnerInstructions are instructions made to external programs as part of the transaction.
+    //
+    // Count == len(I)
+    repeated InnerInstructions inner_instructions = 5;
+//    bool inner_instructions_none = 10;
+    repeated string log_messages = 6;
+//    bool log_messages_none = 11;
+    repeated TokenBalance pre_token_balances = 7;
+    repeated TokenBalance post_token_balances = 8;
+    repeated Reward rewards = 9;
+    repeated bytes loaded_writable_addresses = 12;
+    repeated bytes loaded_readonly_addresses = 13;
+    ReturnData return_data = 14;
+//    bool return_data_none = 15;
+
+    // Sum of compute units consumed by all instructions.
+    // Available since Solana v1.10.35 / v1.11.6.
+    // Set to `None` for txs executed on earlier versions.
+    optional uint64 compute_units_consumed = 16;
+}
+
+
+message TransactionError {
+    bytes err = 1;
+}
+
+message InnerInstructions {
+    uint32 index = 1;
+    repeated InnerInstruction instructions = 2;
+}
+
+message InnerInstruction {
+    uint32 program_id_index = 1;
+    bytes accounts = 2;
+    bytes data = 3;
+
+    // Invocation stack height of an inner instruction.
+    // Available since Solana v1.14.6
+    // Set to `None` for txs executed on earlier versions.
+    optional uint32 stack_height = 4;
+}
+
+message CompiledInstruction {
+    uint32 program_id_index = 1;
+    bytes accounts = 2;
+    bytes data = 3;
+}
+
+message TokenBalance {
+    uint32 account_index = 1;
+    string mint = 2;
+    UiTokenAmount ui_token_amount = 3;
+    string owner = 4;
+    string program_id = 5;
+}
+
+message UiTokenAmount {
+    double ui_amount = 1;
+    uint32 decimals = 2;
+    string amount = 3;
+    string ui_amount_string = 4;
+}
+
+message ReturnData {
+    bytes program_id = 1;
+    bytes data = 2;
+}
+
+enum RewardType {
+    Unspecified = 0;
+    Fee = 1;
+    Rent = 2;
+    Staking = 3;
+    Voting = 4;
+}
+
+message Reward {
+    string pubkey = 1;
+    int64 lamports = 2;
+    uint64 post_balance = 3;
+    RewardType reward_type = 4;
+    string commission = 5;
+}
+
+message Rewards {
+  repeated Reward rewards = 1;
+}
+
+message UnixTimestamp {
+    int64 timestamp = 1;
+}
+
+message BlockHeight {
+    uint64 block_height = 1;
+}

--- a/crates/firehose-protos/protos/sol_block.proto
+++ b/crates/firehose-protos/protos/sol_block.proto
@@ -1,5 +1,6 @@
-// Copyright 2024-, Semiotic AI, Inc.
+// Copyright 2025, StreamingFast
 // SPDX-License-Identifier: Apache-2.0
+// Derived from: https://github.com/streamingfast/firehose-solana
 
 syntax = "proto3";
 

--- a/crates/firehose-protos/protos/sol_block.proto
+++ b/crates/firehose-protos/protos/sol_block.proto
@@ -1,3 +1,6 @@
+// Copyright 2024-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
 syntax = "proto3";
 
 import "google/protobuf/timestamp.proto";

--- a/crates/firehose-protos/src/lib.rs
+++ b/crates/firehose-protos/src/lib.rs
@@ -13,6 +13,13 @@ mod bstream {
     }
 }
 
+mod sol_block {
+    pub mod v1{
+        tonic::include_proto!("sf.solana.r#type.v1");
+    }
+}
+
 pub use bstream::v1::Block as BstreamBlock;
 pub use error::ProtosError;
 pub use ethereum_v2::{eth_block::FullReceipt, Block as EthBlock, BlockHeader};
+pub use sol_block::v1::Block as SolBlock;

--- a/crates/firehose-protos/src/lib.rs
+++ b/crates/firehose-protos/src/lib.rs
@@ -14,7 +14,7 @@ mod bstream {
 }
 
 mod sol_block {
-    pub mod v1{
+    pub mod v1 {
         tonic::include_proto!("sf.solana.r#type.v1");
     }
 }


### PR DESCRIPTION
This PR updates `firehose-protos` to include the use of StreamingFast's Solana Block Protobuf (https://github.com/streamingfast/firehose-solana/blob/develop/proto/sf/solana/type/v1/type.proto).