### PR TITLE
Add AnyBlock and ContentType enums

### DIFF
--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -8,7 +8,7 @@ use std::{
 
 use crate::{dbin::read_block_from_reader, error::DecoderError, DbinFile};
 use firehose_protos::{
-    BigInt, BlockHeader, BstreamBlock, EthBlock as Block, Timestamp, Uint64NestedArray,
+    BigInt, BlockHeader, BstreamBlock, EthBlock as Block, SolBlock, Timestamp, Uint64NestedArray,
 };
 use parquet::{
     file::reader::{FileReader, SerializedFileReader},
@@ -45,6 +45,79 @@ impl From<bool> for Compression {
     }
 }
 
+/// An enumeration of supported chains and associated Block structs
+#[allow(clippy::large_enum_variant)]
+#[derive(Clone, Debug, serde::Serialize)]
+pub enum AnyBlock {
+    /// EVM Block
+    Evm(Block),
+    /// Solana Block
+    Sol(SolBlock),
+}
+
+impl AnyBlock {
+    /// Convert the data associated with an AnyBlock instance into
+    /// a firehose_protos::EthBlock
+    pub fn try_into_eth_block(self) -> Result<Block, DecoderError> {
+        match self {
+            AnyBlock::Evm(block) => Ok(block),
+            _ => Err(DecoderError::ConversionError),
+        }
+    }
+
+    /// Convert the data associated with an AnyBlock instance into
+    /// a firehose_protos::SolBlock
+    pub fn try_into_sol_block(self) -> Result<SolBlock, DecoderError> {
+        match self {
+            AnyBlock::Sol(block) => Ok(block),
+            _ => Err(DecoderError::ConversionError),
+        }
+    }
+
+    /// Borrow-based conversion to extract reference to an EthBlock
+    pub fn as_eth_block(&self) -> Option<&Block> {
+        match self {
+            AnyBlock::Evm(b) => Some(b),
+            _ => None,
+        }
+    }
+
+    /// Borrow-based conversion to extract reference to a SolBlock
+    pub fn as_sol_block(&self) -> Option<&SolBlock> {
+        match self {
+            AnyBlock::Sol(b) => Some(b),
+            _ => None,
+        }
+    }
+}
+
+/// The content type (or proto definition type) is a field in the dbin file structure
+/// which indicates which chain the Blocks represented by the file are from.
+/// So far we have parsed .dbin files containing Blocks
+/// from these enumerated chains, but others may be added in the
+/// future. The content type in the dbin header may also
+/// vary depending on the version of the file.
+#[derive(Clone)]
+pub enum ContentType {
+    /// Indicates EVM Block content.
+    Evm,
+    /// Indicates Solana Block content.
+    Sol,
+}
+
+impl TryFrom<&str> for ContentType {
+    type Error = DecoderError;
+
+    // These are the content types we have so far encountered, but there
+    // are others which may be added in the future.
+    fn try_from(value: &str) -> Result<Self, Self::Error> {
+        match value {
+            "ETH" => Ok(ContentType::Evm),
+            "type.googleapis.com/sf.solana.type.v1.Block" => Ok(ContentType::Sol),
+            _ => Err(DecoderError::ContentTypeInvalid(value.to_string())),
+        }
+    }
+}
 /// Read blocks from a flat file reader.
 ///
 /// This function processes flat files that are already loaded into memory, supporting both

--- a/crates/decoder/src/error.rs
+++ b/crates/decoder/src/error.rs
@@ -18,6 +18,10 @@ pub enum DecoderError {
     #[error("Invalid flat file content type: {0}")]
     ContentTypeInvalid(String),
 
+    /// Error converting from AnyBlock into chain-specific Block.
+    #[error("Error converting into chain block")]
+    ConversionError,
+
     /// [firehose_protos] library error.
     #[error("Protos error: {0}")]
     FirehoseProtosError(#[from] firehose_protos::ProtosError),


### PR DESCRIPTION
This PR follows on PR #99. It adds support for decoding flat files containing Blocks other than those with the Ethereum structure.

The PR adds to the `decoder` crate an `enum AnyBlock`, whose variants represent chains - and associated data of Blocks - for which `decoder` can parse .dbin files. One of the fields in a `DbinHeader` is the `content_type`, which relates the data in a .dbin file to the Protobuf definition with which it was built. The `enum ContentType` lists our currently supported content types and its `try_from` method goes through the actual values found in the dbin headers.

These `enum`s can be extended to add more chains and content types in the future.