### PR TITLE
Refactor decoder methods and examples to support non-EVM chains

### DIFF
--- a/crates/decoder/examples/cli.rs
+++ b/crates/decoder/examples/cli.rs
@@ -240,7 +240,9 @@ fn dir_entry_extension_is_dbin(entry: &DirEntry) -> bool {
     } else {
         path
     };
-    effective_path.extension().map_or(false, |ext| ext == EXTENSION)
+    effective_path
+        .extension()
+        .map_or(false, |ext| ext == EXTENSION)
 }
 
 fn read_flat_files(path: &str, compression: Compression) -> Result<Vec<AnyBlock>, DecoderError> {

--- a/crates/decoder/examples/compression.rs
+++ b/crates/decoder/examples/compression.rs
@@ -6,33 +6,40 @@
 //! This example demonstrates how to read blocks from compressed and uncompressed files.
 //!
 //! Prerequisites:
-//! A dbin file both compressed and uncompressed.
+//! A v0 dbin file both compressed and uncompressed, with message data representing
+//! Ethereum Blocks.
 
 use std::{fs::File, io::BufReader};
 
-use flat_files_decoder::{read_blocks_from_reader, Compression};
+use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
 
 fn main() {
     let path = "example.dbin.zst";
     let blocks_compressed =
         read_blocks_from_reader(create_reader(path), Compression::Zstd).unwrap();
+    let mut block = blocks_compressed.first().unwrap();
+    assert!(matches!(block, AnyBlock::Evm(_)));
     assert_eq!(blocks_compressed.len(), 100);
 
     let path = "example.dbin";
     let blocks_decompressed =
         read_blocks_from_reader(create_reader(path), Compression::None).unwrap();
+    block = blocks_decompressed.first().unwrap();
+    assert!(matches!(block, AnyBlock::Evm(_)));
     assert_eq!(blocks_compressed.len(), blocks_decompressed.len());
     for (b1, b2) in blocks_compressed.into_iter().zip(blocks_decompressed) {
-        assert_eq!(b1.hash, b2.hash);
-        assert_eq!(b1.number, b2.number);
-        assert_eq!(b1.size, b2.size);
-        assert_eq!(b1.header, b2.header);
-        assert_eq!(b1.detail_level, b2.detail_level);
-        assert_eq!(b1.uncles, b2.uncles);
-        assert_eq!(b1.code_changes, b2.code_changes);
-        assert_eq!(b1.balance_changes, b2.balance_changes);
-        assert_eq!(b1.transaction_traces, b2.transaction_traces);
-        assert_eq!(b1.system_calls, b2.system_calls);
+        let v1 = b1.try_into_eth_block().unwrap();
+        let v2 = b2.try_into_eth_block().unwrap();
+        assert_eq!(v1.hash, v2.hash);
+        assert_eq!(v1.number, v2.number);
+        assert_eq!(v1.size, v2.size);
+        assert_eq!(v1.header, v2.header);
+        assert_eq!(v1.detail_level, v2.detail_level);
+        assert_eq!(v1.uncles, v2.uncles);
+        assert_eq!(v1.code_changes, v2.code_changes);
+        assert_eq!(v1.balance_changes, v2.balance_changes);
+        assert_eq!(v1.transaction_traces, v2.transaction_traces);
+        assert_eq!(v1.system_calls, v2.system_calls);
     }
 }
 

--- a/crates/decoder/examples/read_blocks.rs
+++ b/crates/decoder/examples/read_blocks.rs
@@ -5,9 +5,7 @@ use std::{
     fs::File,
     io::{BufReader, BufWriter, Cursor, Write},
 };
-
-use firehose_protos::EthBlock as Block;
-use flat_files_decoder::{stream_blocks, EndBlock, Reader};
+use flat_files_decoder::{stream_blocks, AnyBlock, EndBlock, Reader};
 
 fn main() {
     let mut buffer = Vec::new();
@@ -27,7 +25,7 @@ fn main() {
 
     let reader = BufReader::new(cursor);
 
-    let blocks: Vec<Block> = stream_blocks(Reader::Buf(reader), EndBlock::MergeBlock)
+    let blocks: Vec<AnyBlock> = stream_blocks(Reader::Buf(reader), EndBlock::MergeBlock)
         .unwrap()
         .collect();
 
@@ -36,6 +34,9 @@ fn main() {
 
     println!("Read blocks:");
     for block in blocks {
-        println!("{:?}", block.number);
+        // `block` is an `AnyBlock`; convert into an `EthBlock`.
+        // If test file does not contain `EthBlock`s, this will produce a ConversionError.
+        let eth_block = block.try_into_eth_block().unwrap();
+        println!("{:?}", eth_block.number);
     }
 }

--- a/crates/decoder/examples/read_blocks.rs
+++ b/crates/decoder/examples/read_blocks.rs
@@ -1,11 +1,11 @@
 // Copyright 2024-, Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+use flat_files_decoder::{stream_blocks, AnyBlock, EndBlock, Reader};
 use std::{
     fs::File,
     io::{BufReader, BufWriter, Cursor, Write},
 };
-use flat_files_decoder::{stream_blocks, AnyBlock, EndBlock, Reader};
 
 fn main() {
     let mut buffer = Vec::new();

--- a/crates/decoder/src/dbin.rs
+++ b/crates/decoder/src/dbin.rs
@@ -123,12 +123,12 @@ pub struct DbinHeader {
     /// File format version, the next single byte after the 4 [`DbinMagicBytes`]
     version: Version,
     /// Content type like 'ETH', 'type.googleapis.com/sf.ethereum.type.v2.Block'
-    content_type: String,
+    pub content_type: String,
 }
 
 impl DbinHeader {
     /// Reads and validates the `.dbin` header from the given [`Read`] source.
-    fn try_from_read<R: Read>(read: &mut R) -> Result<Self, DecoderError> {
+    pub fn try_from_read<R: Read>(read: &mut R) -> Result<Self, DecoderError> {
         let magic_bytes = read_magic_bytes(read)?;
         if !magic_bytes_valid(&magic_bytes) {
             return Err(DecoderError::MagicBytesInvalid);

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -6,7 +6,7 @@ use std::{
     io::{BufReader, Cursor, Read},
 };
 
-use crate::{dbin::read_block_from_reader, error::DecoderError, DbinFile};
+use crate::{dbin::read_block_from_reader, error::DecoderError, DbinFile, DbinHeader};
 use firehose_protos::{
     BigInt, BlockHeader, BstreamBlock, EthBlock as Block, SolBlock, Timestamp, Uint64NestedArray,
 };
@@ -143,8 +143,7 @@ impl TryFrom<&str> for ContentType {
 pub fn read_blocks_from_reader<R: Read>(
     reader: R,
     compression: Compression,
-) -> Result<Vec<Block>, DecoderError> {
-    const CONTENT_TYPE: &str = "ETH";
+) -> Result<Vec<AnyBlock>, DecoderError> {
 
     let mut file_contents: Box<dyn Read> = match compression {
         Compression::Zstd => Box::new(Cursor::new(zstd::decode_all(reader)?)),
@@ -152,19 +151,16 @@ pub fn read_blocks_from_reader<R: Read>(
     };
 
     let dbin_file = DbinFile::try_from_read(&mut file_contents)?;
-    if dbin_file.content_type() != CONTENT_TYPE {
-        return Err(DecoderError::ContentTypeInvalid(
-            dbin_file.content_type().to_string(),
-        ));
-    }
+    let content_type: ContentType = dbin_file.content_type().try_into()?;
 
     dbin_file
         .into_iter()
         .map(|message| {
-            let block = decode_block_from_bytes(&message)?;
-            if !block_is_verified(&block) {
+            let block = decode_block_from_bytes(&message, content_type.clone())?;
+            let (verified, number) = block_is_verified(&block);
+            if !verified {
                 Err(DecoderError::VerificationFailed {
-                    block_number: block.number,
+                    block_number: number,
                 })
             } else {
                 Ok(block)
@@ -173,25 +169,34 @@ pub fn read_blocks_from_reader<R: Read>(
         .collect()
 }
 
-fn block_is_verified(block: &Block) -> bool {
-    if block.number != 0 {
-        if !block.receipt_root_is_verified() {
-            error!(
-                "Receipt root verification failed for block {}",
-                block.number
-            );
-            return false;
+fn block_is_verified(block: &AnyBlock) -> (bool, u64) {
+    match block {
+        AnyBlock::Evm(eth_block) => {
+            let block_number = eth_block.number;
+            if block_number != 0 {
+                if !eth_block.receipt_root_is_verified() {
+                    error!(
+                        "Receipt root verification failed for block {}",
+                        block_number
+                    );
+                    return (false, block_number);
+                }
+                if !eth_block.transaction_root_is_verified() {
+                    error!(
+                        "Transaction root verification failed for block {}",
+                        block_number
+                    );
+                    return (false, block_number);
+                }
+            }
+            (true, block_number)
         }
-
-        if !block.transaction_root_is_verified() {
-            error!(
-                "Transaction root verification failed for block {}",
-                block.number
-            );
-            return false;
+        // Logic is not yet implemented for verifying Solana Blocks
+        AnyBlock::Sol(sol_block) => {
+            let block_number = sol_block.block_height.unwrap().block_height;
+            (true, block_number)
         }
     }
-    true
 }
 
 /// Reader enum to handle different types of readers
@@ -271,7 +276,7 @@ impl From<Option<u64>> for EndBlock {
 pub fn stream_blocks(
     reader: Reader,
     end_block: EndBlock,
-) -> Result<impl Iterator<Item = Block>, DecoderError> {
+) -> Result<impl Iterator<Item = AnyBlock>, DecoderError> {
     let mut current_block_number = 0;
 
     let mut reader = reader.into_reader()?;
@@ -279,17 +284,20 @@ pub fn stream_blocks(
 
     let mut blocks = Vec::new();
 
+    let header = DbinHeader::try_from_read(&mut reader)?;
+    let content_type: ContentType = header.content_type.as_str().try_into()?;
+
     loop {
         match read_block_from_reader(&mut reader) {
             Ok(message) => {
-                match decode_block_from_bytes(&message) {
+                match decode_block_from_bytes(&message, content_type.clone()) {
                     Ok(block) => {
-                        current_block_number = block.number;
-
-                        if block_is_verified(&block) {
+                        let (verified, number) = block_is_verified(&block);
+                        current_block_number = number;
+                        if verified {
                             blocks.push(block);
                         } else {
-                            info!("Block verification failed, skipping block {}", block.number);
+                            info!("Block verification failed, skipping block {}", number);
                         }
                     }
                     Err(e) => return Err(e),
@@ -311,10 +319,26 @@ pub fn stream_blocks(
 
 /// Decodes a block from a byte slice.
 #[allow(deprecated)]
-fn decode_block_from_bytes(bytes: &[u8]) -> Result<Block, DecoderError> {
+fn decode_block_from_bytes(
+    bytes: &[u8],
+    content_type: ContentType,
+) -> Result<AnyBlock, DecoderError> {
     let block_stream = BstreamBlock::decode(bytes)?;
-    let block = Block::decode(block_stream.payload_buffer.as_slice())?;
-    Ok(block)
+        let block_stream_payload = block_stream
+        .payload
+        .map(|p| p.value)
+        .unwrap_or(block_stream.payload_buffer);
+
+    match content_type {
+        ContentType::Evm => {
+            let block = Block::decode(block_stream_payload.as_slice())?;
+            Ok(AnyBlock::Evm(block))
+        }
+        ContentType::Sol => {
+            let block = SolBlock::decode(block_stream_payload.as_slice())?;
+            Ok(AnyBlock::Sol(block))
+        }
+    }
 }
 
 /// Converts a Parquet file containing block header data (from nozzle) into [`Vec<BlockHeader>`]

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -413,22 +413,13 @@ mod tests {
         let file = File::open("tests/000000000.parquet").unwrap();
         let _ = parquet_to_headers(file);
     }
-}
-
-#[cfg(test)]
-mod tests {
-    use std::fs::{self, File};
-
-    use tracing_subscriber::field::debug;
-
-    use super::*;
 
     #[test]
     fn test_read_eth_block_from_reader() {
         let file = File::open("tests/0000000000.dbin").unwrap();
         let mut reader = BufReader::new(file);
 
-        let block = read_blocks_from_reader(&mut reader, false.into()).unwrap();
+        let _block = read_blocks_from_reader(&mut reader, false.into()).unwrap();
     }
 
     #[test]
@@ -436,6 +427,34 @@ mod tests {
         let file = File::open("tests/0325942300.dbin.zst").unwrap();
         let mut reader = BufReader::new(file);
 
-        let block = read_blocks_from_reader(&mut reader, true.into()).unwrap();
+        let _block = read_blocks_from_reader(&mut reader, true.into()).unwrap();
+    }
+
+    #[test]
+    fn test_unwrap_eth_block() {
+        let file = File::open("tests/0000000000.dbin").unwrap();
+        let mut reader = BufReader::new(file);
+        let any_blocks = read_blocks_from_reader(&mut reader, false.into()).unwrap();
+        let any_block = any_blocks.first().unwrap();
+        let block = any_block.clone().try_into_eth_block().unwrap();
+
+        let hash = [
+            212, 229, 103, 64, 248, 118, 174, 248, 192, 16, 184, 106, 64, 213, 245, 103, 69, 161,
+            24, 208, 144, 106, 52, 230, 154, 236, 140, 13, 177, 203, 143, 163,
+        ];
+
+        assert_eq!(block.hash, hash);
+    }
+
+    #[test]
+    fn test_unwrap_sol_block() {
+        let file = File::open("tests/0325942300.dbin.zst").unwrap();
+        let mut reader = BufReader::new(file);
+        let any_blocks = read_blocks_from_reader(&mut reader, true.into()).unwrap();
+        let any_block = any_blocks.first().unwrap();
+        let block = any_block.clone().try_into_sol_block().unwrap();
+
+        let hash: String = "8NQ2DstBY2HukX2JQPL7ejdRN1FVxdLG6mnH9Sv25thC".into();
+        assert_eq!(block.blockhash, hash);
     }
 }

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -414,3 +414,28 @@ mod tests {
         let _ = parquet_to_headers(file);
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use std::fs::{self, File};
+
+    use tracing_subscriber::field::debug;
+
+    use super::*;
+
+    #[test]
+    fn test_read_eth_block_from_reader() {
+        let file = File::open("tests/0000000000.dbin").unwrap();
+        let mut reader = BufReader::new(file);
+
+        let block = read_blocks_from_reader(&mut reader, false.into()).unwrap();
+    }
+
+    #[test]
+    fn test_read_sol_block_from_reader() {
+        let file = File::open("tests/0325942300.dbin.zst").unwrap();
+        let mut reader = BufReader::new(file);
+
+        let block = read_blocks_from_reader(&mut reader, true.into()).unwrap();
+    }
+}

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -144,7 +144,6 @@ pub fn read_blocks_from_reader<R: Read>(
     reader: R,
     compression: Compression,
 ) -> Result<Vec<AnyBlock>, DecoderError> {
-
     let mut file_contents: Box<dyn Read> = match compression {
         Compression::Zstd => Box::new(Cursor::new(zstd::decode_all(reader)?)),
         Compression::None => Box::new(reader),
@@ -324,7 +323,7 @@ fn decode_block_from_bytes(
     content_type: ContentType,
 ) -> Result<AnyBlock, DecoderError> {
     let block_stream = BstreamBlock::decode(bytes)?;
-        let block_stream_payload = block_stream
+    let block_stream_payload = block_stream
         .payload
         .map(|p| p.value)
         .unwrap_or(block_stream.payload_buffer);

--- a/crates/header-accumulator/README.md
+++ b/crates/header-accumulator/README.md
@@ -62,7 +62,7 @@ cargo test
 
 ```rust,no_run
 use std::{fs::File, io::BufReader};
-use flat_files_decoder::{read_blocks_from_reader, Compression};
+use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
 use header_accumulator::{
     generate_inclusion_proofs, verify_inclusion_proofs, Epoch, EraValidateError, Header,
 };
@@ -80,12 +80,27 @@ fn main() -> Result<(), EraValidateError> {
             Compression::None,
         ) {
             Ok(blocks) => {
-                headers.extend(
-                    blocks
-                        .iter()
-                        .map(|block| Header::try_from(block).unwrap())
-                        .collect::<Vec<Header>>(),
-                );
+                // Check if the Blocks contained in the .dbin files are Ethereum type.
+                // Header Accumulators are currently only supported for Ethereum type
+                // blocks.
+                match blocks.first().unwrap(){
+                    AnyBlock::Evm(_) =>
+                    {
+                        headers.extend(
+                            blocks
+                            .iter()
+                            .filter_map(|block| {
+                                if let AnyBlock::Evm(ref eth_block) = *block {
+                                    Header::try_from(eth_block).ok()
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<Header>>(),
+                        );
+                    }
+                    _ => println!("File does not contain Ethereum Blocks: {}", file)
+                } 
             }
             Err(e) => {
                 eprintln!("error: {:?}", e);
@@ -126,7 +141,7 @@ fn main() -> Result<(), EraValidateError> {
 ```rust,no_run
 use std::{fs::File, io::BufReader};
 
-use flat_files_decoder::{read_blocks_from_reader, Compression};
+use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
 use header_accumulator::{Epoch, EraValidateError, EraValidator, Header};
 use tree_hash::Hash256;
 
@@ -143,13 +158,29 @@ fn main() -> Result<(), EraValidateError> {
         );
         let reader = create_test_reader(&file_name);
         let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
-        let successful_headers = blocks
-            .iter()
-            .cloned()
-            .map(|block| Header::try_from(&block))
-            .collect::<Result<Vec<_>, _>>()?;
-        headers.extend(successful_headers);
+        // Check if the Blocks contained in the .dbin files are Ethereum type.
+        // Header Accumulators are currently only supported for Ethereum type
+        // blocks.
+        match blocks.first().unwrap(){
+            AnyBlock::Evm(_) =>
+            {
+                let successful_headers = blocks
+                    .iter()
+                    .cloned()
+                    .filter_map(|block| {
+                        if let AnyBlock::Evm(eth_block) = block {
+                            Header::try_from(&eth_block).ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<Header>>();
+                headers.extend(successful_headers);
+            }
+            _ => println!("File does not contain Ethereum Blocks: {}", file_name)
+        }
     }
+    
     assert_eq!(headers.len(), 8300);
     assert_eq!(headers[0].number, 0);
     let era_verifier = EraValidator::default();

--- a/crates/vee/README.md
+++ b/crates/vee/README.md
@@ -26,12 +26,12 @@ inclusion proofs are for verifying specific blocks to be part of canonical epoch
 ```rust,no_run
 use std::{fs::File, io::BufReader};
 use vee::{
-    generate_inclusion_proofs, read_blocks_from_reader, verify_inclusion_proofs, Compression,
-    Epoch, EraValidateError, Header,
+    generate_inclusion_proofs, read_blocks_from_reader, verify_inclusion_proofs, 
+    AnyBlock, Compression, Epoch, EraValidateError, Header,
 };
 
 fn main() -> Result<(), EraValidateError> {
-    let mut headers: Vec<Header> = Vec::new();
+   let mut headers: Vec<Header> = Vec::new();
 
     for flat_file_number in (0..=8200).step_by(100) {
         let file = format!(
@@ -43,12 +43,27 @@ fn main() -> Result<(), EraValidateError> {
             Compression::None,
         ) {
             Ok(blocks) => {
-                headers.extend(
-                    blocks
-                        .iter()
-                        .map(|block| Header::try_from(block).unwrap())
-                        .collect::<Vec<Header>>(),
-                );
+                // Check if the Blocks contained in the .dbin files are Ethereum type.
+                // Header Accumulators are currently only supported for Ethereum type
+                // blocks.
+                match blocks.first().unwrap(){
+                    AnyBlock::Evm(_) =>
+                    {
+                        headers.extend(
+                            blocks
+                            .iter()
+                            .filter_map(|block| {
+                                if let AnyBlock::Evm(ref eth_block) = *block {
+                                    Header::try_from(eth_block).ok()
+                                } else {
+                                    None
+                                }
+                            })
+                            .collect::<Vec<Header>>(),
+                        );
+                    }
+                    _ => println!("File does not contain Ethereum Blocks: {}", file)
+                } 
             }
             Err(e) => {
                 eprintln!("error: {:?}", e);
@@ -86,54 +101,67 @@ fn main() -> Result<(), EraValidateError> {
 
 ### Era validator
 
-Epochs by themselves can be validated to be canonical]
-wit the example below.
+Epochs by themselves can be validated to be canonical
+with the example below.
 
 ```rust,no_run
 use std::{fs::File, io::BufReader};
 use tree_hash::Hash256;
 use vee::{
-    read_blocks_from_reader, Compression, Epoch, EraValidateError, EraValidator,
-    Header,
+    read_blocks_from_reader, AnyBlock, Compression, Epoch, EraValidateError, 
+    EraValidator, Header,
 };
 
 fn create_test_reader(path: &str) -> BufReader<File> {
-     BufReader::new(File::open(path).unwrap())
+    BufReader::new(File::open(path).unwrap())
 }
 
 fn main() -> Result<(), EraValidateError> {
-     let mut headers: Vec<Header> = Vec::new();
+    let mut headers: Vec<Header> = Vec::new();
+    for number in (0..=8200).step_by(100) {
+        let file_name = format!(
+            "your-test-assets/ethereum_firehose_first_8200/{:010}.dbin",
+            number
+        );
+        let reader = create_test_reader(&file_name);
+        let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
+        // Check if the Blocks contained in the .dbin files are Ethereum type.
+        // Header Accumulators are currently only supported for Ethereum type
+        // blocks.
+        match blocks.first().unwrap(){
+            AnyBlock::Evm(_) =>
+            {
+                let successful_headers = blocks
+                    .iter()
+                    .cloned()
+                    .filter_map(|block| {
+                        if let AnyBlock::Evm(eth_block) = block {
+                            Header::try_from(&eth_block).ok()
+                        } else {
+                            None
+                        }
+                    })
+                    .collect::<Vec<Header>>();
+                headers.extend(successful_headers);
+            }
+            _ => println!("File does not contain Ethereum Blocks: {}", file_name)
+        }
+    }
+    
+    assert_eq!(headers.len(), 8300);
+    assert_eq!(headers[0].number, 0);
+    let era_verifier = EraValidator::default();
+    let epoch: Epoch = headers.try_into().unwrap();
+    let result = era_verifier.validate_era(&epoch)?;
+    let expected = Hash256::new([
+        94, 193, 255, 184, 195, 177, 70, 244, 38, 6, 199, 76, 237, 151, 61, 193, 110, 197, 161, 7,
+        192, 52, 88, 88, 195, 67, 252, 148, 120, 11, 66, 24,
+    ]);
+    assert_eq!(result, expected);
 
-     for number in (0..=8200).step_by(100) {
-         let file_name = format!(
-             "your-test-assets/ethereum_firehose_first_8200/{:010}.dbin",
-             number
-         );
-         let reader = create_test_reader(&file_name);
-         let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
-         let successful_headers = blocks
-             .iter()
-             .cloned()
-             .map(|block| Header::try_from(&block))
-             .collect::<Result<Vec<_>, _>>()?;
-         headers.extend(successful_headers);
-     }
+    println!("Era validated successfully!");
 
-     assert_eq!(headers.len(), 8300);
-     assert_eq!(headers[0].number, 0);
-
-     let era_verifier = EraValidator::default();
-     let epoch: Epoch = headers.try_into().unwrap();
-     let result = era_verifier.validate_era(&epoch)?;
-     let expected = Hash256::new([
-         94, 193, 255, 184, 195, 177, 70, 244, 38, 6, 199, 76, 237, 151, 61, 193, 110, 197, 161, 7,
-         192, 52, 88, 88, 195, 67, 252, 148, 120, 11, 66, 24,
-     ]);
-     assert_eq!(result, expected);
-
-     println!("Era validated successfully!");
-
-     Ok(())
+    Ok(())
 }
 ```
 


### PR DESCRIPTION
This PR builds on PR #100 and PR #99. It updates the methods in `decoder.rs` to parse .dbin files containing Blocks from all currently supported chains, as enumerated in `enum AnyBlock`. Changing these methods prompted a refactor of the examples in the `decoder` crate as well.