### PR TITLE
Add method to verify block hash

### DIFF
--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -196,10 +196,7 @@ fn block_is_verified(block: &AnyBlock) -> (bool, u64) {
                     return (false, block_number);
                 }
                 if !eth_block.block_hash_is_verified() {
-                    error!(
-                        "Block hash verification failed for block {}",
-                        block_number
-                    );
+                    error!("Block hash verification failed for block {}", block_number);
                     return (false, block_number);
                 }
             }

--- a/crates/decoder/src/decoder.rs
+++ b/crates/decoder/src/decoder.rs
@@ -168,7 +168,7 @@ pub fn read_blocks_from_reader<R: Read>(
         .collect()
 }
 
-/// Validate the contents of the Block (e.g., transactions, receipts)
+/// Validate the contents of the Block (e.g., transactions, receipts, block hash)
 /// against the self-contained information in the block (such as Merkle
 /// tree roots). This is a check that the contents of the block are correct,
 /// but does not validate the inclusion of the Block in the chain's
@@ -191,6 +191,13 @@ fn block_is_verified(block: &AnyBlock) -> (bool, u64) {
                 if !eth_block.transaction_root_is_verified() {
                     error!(
                         "Transaction root verification failed for block {}",
+                        block_number
+                    );
+                    return (false, block_number);
+                }
+                if !eth_block.block_hash_is_verified() {
+                    error!(
+                        "Block hash verification failed for block {}",
                         block_number
                     );
                     return (false, block_number);


### PR DESCRIPTION
Because an EVM block header are used to verify the inclusion of the block in the chain's history, it is important that the block hash, calculated from the contents of the header, matches what is recorded in the block. In this PR, we add a method to verify the calculated block hash against the `hash` field of the `Header`. We then use this method in `decoder`, alongside receipts and transactions roots verification, to validate the contents of an extracted block.