### PR TITLE
Revert "refactor: remove ExtHeaderRecord"

### DIFF
--- a/crates/header-accumulator/README.md
+++ b/crates/header-accumulator/README.md
@@ -30,13 +30,13 @@ cd crates/header-accumulator && cargo doc --open
 - **`generate_inclusion_proof`**: Generates inclusion proofs for a
   specified range of blocks, useful for verifying the presence of
   specific blocks within a dataset.
-- **`verify_inclusion_proof`**: Verifies inclusion proofs for a
+- **`verify_inclusion_proof`**: Verifies inclusion proofs for a 
   specified range of blocks. Use this to confirm the accuracy of
   inclusion proofs.
 
 ### Options
 
-- `-h, --help`: Displays a help message that includes usage
+- `-h, --help`: Displays a help message that includes usage 
   information, commands, and options.
 
 ## Goals
@@ -64,54 +64,41 @@ cargo test
 use std::{fs::File, io::BufReader};
 use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
 use header_accumulator::{
-    generate_inclusion_proofs, verify_inclusion_proofs, Epoch, EraValidateError, Header,
+    generate_inclusion_proofs, verify_inclusion_proofs, Epoch, EraValidateError, ExtHeaderRecord,
 };
 
 fn main() -> Result<(), EraValidateError> {
-   let mut headers: Vec<Header> = Vec::new();
+   let mut headers: Vec<ExtHeaderRecord> = Vec::new();
 
     for flat_file_number in (0..=8200).step_by(100) {
         let file = format!(
             "your_files/ethereum_firehose_first_8200/{:010}.dbin",
             flat_file_number
         );
-        match read_blocks_from_reader(
+        let blocks =  read_blocks_from_reader(
             BufReader::new(File::open(&file).unwrap()),
             Compression::None,
-        ) {
-            Ok(blocks) => {
-                // Check if the Blocks contained in the .dbin files are Ethereum type.
-                // Header Accumulators are currently only supported for Ethereum type
-                // blocks.
-                match blocks.first().unwrap(){
-                    AnyBlock::Evm(_) =>
-                    {
-                        headers.extend(
-                            blocks
-                            .iter()
-                            .filter_map(|block| {
-                                if let AnyBlock::Evm(ref eth_block) = *block {
-                                    Header::try_from(eth_block).ok()
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<Header>>(),
-                        );
-                    }
-                    _ => println!("File does not contain Ethereum Blocks: {}", file)
-                } 
-            }
-            Err(e) => {
-                eprintln!("error: {:?}", e);
-                break;
-            }
-        }
+        ).unwrap();
+        headers.extend(
+            blocks
+            .iter()
+            .filter_map(|block| {
+                if let AnyBlock::Evm(eth_block) = block {
+                    ExtHeaderRecord::try_from(eth_block).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<ExtHeaderRecord>>(),
+        );
     }
 
     let start_block = 301;
     let end_block = 402;
-    let headers_to_prove = headers[start_block..end_block].to_vec();
+    let headers_to_prove: Vec<_> = headers[start_block..end_block]
+        .iter()
+        .map(|ext| ext.full_header.as_ref().unwrap().clone())
+        .collect();
     let epoch: Epoch = headers.try_into().unwrap();
 
     let inclusion_proof = generate_inclusion_proofs(vec![epoch], headers_to_prove.clone())
@@ -133,7 +120,7 @@ fn main() -> Result<(), EraValidateError> {
     println!("Inclusion proof verified successfully!");
 
     Ok(())
-}
+}    
 ```
 
 ### Era validator
@@ -142,7 +129,7 @@ fn main() -> Result<(), EraValidateError> {
 use std::{fs::File, io::BufReader};
 
 use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
-use header_accumulator::{Epoch, EraValidateError, EraValidator, Header};
+use header_accumulator::{Epoch, EraValidateError, EraValidator, ExtHeaderRecord};
 use tree_hash::Hash256;
 
 fn create_test_reader(path: &str) -> BufReader<File> {
@@ -150,7 +137,7 @@ fn create_test_reader(path: &str) -> BufReader<File> {
 }
 
 fn main() -> Result<(), EraValidateError> {
-    let mut headers: Vec<Header> = Vec::new();
+    let mut headers: Vec<ExtHeaderRecord> = Vec::new();
     for number in (0..=8200).step_by(100) {
         let file_name = format!(
             "your-test-assets/ethereum_firehose_first_8200/{:010}.dbin",
@@ -158,31 +145,21 @@ fn main() -> Result<(), EraValidateError> {
         );
         let reader = create_test_reader(&file_name);
         let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
-        // Check if the Blocks contained in the .dbin files are Ethereum type.
-        // Header Accumulators are currently only supported for Ethereum type
-        // blocks.
-        match blocks.first().unwrap(){
-            AnyBlock::Evm(_) =>
-            {
-                let successful_headers = blocks
-                    .iter()
-                    .cloned()
-                    .filter_map(|block| {
-                        if let AnyBlock::Evm(eth_block) = block {
-                            Header::try_from(&eth_block).ok()
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<Header>>();
-                headers.extend(successful_headers);
-            }
-            _ => println!("File does not contain Ethereum Blocks: {}", file_name)
-        }
+        let successful_headers = blocks
+            .iter()
+            .filter_map(|block| {
+                if let AnyBlock::Evm(eth_block) = block {
+                    ExtHeaderRecord::try_from(eth_block).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        headers.extend(successful_headers);
     }
     
     assert_eq!(headers.len(), 8300);
-    assert_eq!(headers[0].number, 0);
+    assert_eq!(headers[0].block_number, 0);
     let era_verifier = EraValidator::default();
     let epoch: Epoch = headers.try_into().unwrap();
     let result = era_verifier.validate_era(&epoch)?;

--- a/crates/header-accumulator/src/lib.rs
+++ b/crates/header-accumulator/src/lib.rs
@@ -8,8 +8,10 @@ mod epoch;
 mod era_validator;
 mod errors;
 mod inclusion_proof;
+mod types;
 
 pub use epoch::*;
 pub use era_validator::*;
 pub use errors::*;
 pub use inclusion_proof::*;
+pub use types::*;

--- a/crates/header-accumulator/src/types.rs
+++ b/crates/header-accumulator/src/types.rs
@@ -1,0 +1,83 @@
+// Copyright 2024-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloy_primitives::{Uint, B256};
+use ethportal_api::{types::execution::accumulator::HeaderRecord, Header};
+use firehose_protos::{BlockHeader, EthBlock as Block};
+
+use crate::errors::EraValidateError;
+
+/// Extension of header with conversion traits
+///
+/// It's capable of converting to HeaderRecord to be used inside Epochs.
+/// It can also convert to firehose protos.
+/// You can extract the full header as an option
+#[derive(Clone)]
+pub struct ExtHeaderRecord {
+    /// Block hash
+    pub block_hash: B256,
+    /// Total difficulty
+    pub total_difficulty: Uint<256, 4>,
+    /// Block number
+    pub block_number: u64,
+    /// Full header
+    pub full_header: Option<Header>,
+}
+
+impl From<ExtHeaderRecord> for HeaderRecord {
+    fn from(
+        ExtHeaderRecord {
+            block_hash,
+            total_difficulty,
+            ..
+        }: ExtHeaderRecord,
+    ) -> Self {
+        HeaderRecord {
+            block_hash,
+            total_difficulty,
+        }
+    }
+}
+
+impl TryFrom<ExtHeaderRecord> for Header {
+    type Error = EraValidateError;
+
+    fn try_from(ext: ExtHeaderRecord) -> Result<Self, Self::Error> {
+        ext.full_header
+            .ok_or(EraValidateError::ExtHeaderRecordError(ext.block_number))
+    }
+}
+
+impl From<&ExtHeaderRecord> for HeaderRecord {
+    fn from(ext: &ExtHeaderRecord) -> Self {
+        HeaderRecord {
+            block_hash: ext.block_hash,
+            total_difficulty: ext.total_difficulty,
+        }
+    }
+}
+
+/// Decodes a [`ExtHeaderRecord`] from a [`Block`]. A [`BlockHeader`] must be present in the block,
+/// otherwise validating headers won't be possible
+impl TryFrom<&Block> for ExtHeaderRecord {
+    type Error = EraValidateError;
+
+    fn try_from(block: &Block) -> Result<Self, Self::Error> {
+        let header: &BlockHeader = block
+            .header
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+
+        let total_difficulty = header
+            .total_difficulty
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+
+        Ok(ExtHeaderRecord {
+            block_number: block.number,
+            block_hash: B256::from_slice(&block.hash),
+            total_difficulty: Uint::from_be_slice(total_difficulty.bytes.as_slice()),
+            full_header: Some(block.try_into()?),
+        })
+    }
+}


### PR DESCRIPTION
This reverts commit 19ed2e6568acab2e064e164f873944676c143a82.
The referenced commit replaced `ExtHeaderRecord` defined in `header-accumulator/src/types.rs` with the `ethportal-api` `Header` struct for simplicity. This struct was used in the doctests in the `header-accumulator` and `vee` README files to construct an `Epoch` to prove inclusion of an EVM block in the chain's pre-merge history.

The `EpochAccumulator` is a `VariableList` of `HeaderRecords`, which contain the `total_difficulty` of each header. This is the _cumulative_ difficulty of blocks ([https://github.com/semiotic-ai/veemon/blob/124b306fc86ed64fd42e77f231eccc636a885cc2/crates/firehose-protos/protos/block.proto#L168](url)).

So when the `HeaderRecord` is populated with `difficulty` ([https://github.com/semiotic-ai/veemon/blob/124b306fc86ed64fd42e77f231eccc636a885cc2/crates/header-accumulator/src/epoch.rs#L84](url)) rather than `total_difficulty`, there is a mismatch between our accumulator and the historical record. Because the `ethportal-api` `Header` does not contain a field for `total_difficulty`, this reversion is being made so that the doctests will run successfully.

While reverting to the use of `ExtHeaderRecord` in the docs, merging was performed with other recent updates to the README files, and some simplifications in the code were made in the process.
