### PR TITLE
Add example to vee for pre-merge block verification

### DIFF
--- a/crates/header-accumulator/README.md
+++ b/crates/header-accumulator/README.md
@@ -30,13 +30,13 @@ cd crates/header-accumulator && cargo doc --open
 - **`generate_inclusion_proof`**: Generates inclusion proofs for a
   specified range of blocks, useful for verifying the presence of
   specific blocks within a dataset.
-- **`verify_inclusion_proof`**: Verifies inclusion proofs for a
+- **`verify_inclusion_proof`**: Verifies inclusion proofs for a 
   specified range of blocks. Use this to confirm the accuracy of
   inclusion proofs.
 
 ### Options
 
-- `-h, --help`: Displays a help message that includes usage
+- `-h, --help`: Displays a help message that includes usage 
   information, commands, and options.
 
 ## Goals
@@ -64,54 +64,41 @@ cargo test
 use std::{fs::File, io::BufReader};
 use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
 use header_accumulator::{
-    generate_inclusion_proofs, verify_inclusion_proofs, Epoch, EraValidateError, Header,
+    generate_inclusion_proofs, verify_inclusion_proofs, Epoch, EraValidateError, ExtHeaderRecord,
 };
 
 fn main() -> Result<(), EraValidateError> {
-   let mut headers: Vec<Header> = Vec::new();
+   let mut headers: Vec<ExtHeaderRecord> = Vec::new();
 
     for flat_file_number in (0..=8200).step_by(100) {
         let file = format!(
             "your_files/ethereum_firehose_first_8200/{:010}.dbin",
             flat_file_number
         );
-        match read_blocks_from_reader(
+        let blocks =  read_blocks_from_reader(
             BufReader::new(File::open(&file).unwrap()),
             Compression::None,
-        ) {
-            Ok(blocks) => {
-                // Check if the Blocks contained in the .dbin files are Ethereum type.
-                // Header Accumulators are currently only supported for Ethereum type
-                // blocks.
-                match blocks.first().unwrap(){
-                    AnyBlock::Evm(_) =>
-                    {
-                        headers.extend(
-                            blocks
-                            .iter()
-                            .filter_map(|block| {
-                                if let AnyBlock::Evm(ref eth_block) = *block {
-                                    Header::try_from(eth_block).ok()
-                                } else {
-                                    None
-                                }
-                            })
-                            .collect::<Vec<Header>>(),
-                        );
-                    }
-                    _ => println!("File does not contain Ethereum Blocks: {}", file)
-                } 
-            }
-            Err(e) => {
-                eprintln!("error: {:?}", e);
-                break;
-            }
-        }
+        ).unwrap();
+        headers.extend(
+            blocks
+            .iter()
+            .filter_map(|block| {
+                if let AnyBlock::Evm(eth_block) = block {
+                    ExtHeaderRecord::try_from(eth_block).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<ExtHeaderRecord>>(),
+        );
     }
 
     let start_block = 301;
     let end_block = 402;
-    let headers_to_prove = headers[start_block..end_block].to_vec();
+    let headers_to_prove: Vec<_> = headers[start_block..end_block]
+        .iter()
+        .map(|ext| ext.full_header.as_ref().unwrap().clone())
+        .collect();
     let epoch: Epoch = headers.try_into().unwrap();
 
     let inclusion_proof = generate_inclusion_proofs(vec![epoch], headers_to_prove.clone())
@@ -133,7 +120,7 @@ fn main() -> Result<(), EraValidateError> {
     println!("Inclusion proof verified successfully!");
 
     Ok(())
-}
+}    
 ```
 
 ### Era validator
@@ -142,7 +129,7 @@ fn main() -> Result<(), EraValidateError> {
 use std::{fs::File, io::BufReader};
 
 use flat_files_decoder::{read_blocks_from_reader, AnyBlock, Compression};
-use header_accumulator::{Epoch, EraValidateError, EraValidator, Header};
+use header_accumulator::{Epoch, EraValidateError, EraValidator, ExtHeaderRecord};
 use tree_hash::Hash256;
 
 fn create_test_reader(path: &str) -> BufReader<File> {
@@ -150,7 +137,7 @@ fn create_test_reader(path: &str) -> BufReader<File> {
 }
 
 fn main() -> Result<(), EraValidateError> {
-    let mut headers: Vec<Header> = Vec::new();
+    let mut headers: Vec<ExtHeaderRecord> = Vec::new();
     for number in (0..=8200).step_by(100) {
         let file_name = format!(
             "your-test-assets/ethereum_firehose_first_8200/{:010}.dbin",
@@ -158,31 +145,21 @@ fn main() -> Result<(), EraValidateError> {
         );
         let reader = create_test_reader(&file_name);
         let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
-        // Check if the Blocks contained in the .dbin files are Ethereum type.
-        // Header Accumulators are currently only supported for Ethereum type
-        // blocks.
-        match blocks.first().unwrap(){
-            AnyBlock::Evm(_) =>
-            {
-                let successful_headers = blocks
-                    .iter()
-                    .cloned()
-                    .filter_map(|block| {
-                        if let AnyBlock::Evm(eth_block) = block {
-                            Header::try_from(&eth_block).ok()
-                        } else {
-                            None
-                        }
-                    })
-                    .collect::<Vec<Header>>();
-                headers.extend(successful_headers);
-            }
-            _ => println!("File does not contain Ethereum Blocks: {}", file_name)
-        }
+        let successful_headers = blocks
+            .iter()
+            .filter_map(|block| {
+                if let AnyBlock::Evm(eth_block) = block {
+                    ExtHeaderRecord::try_from(eth_block).ok()
+                } else {
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        headers.extend(successful_headers);
     }
     
     assert_eq!(headers.len(), 8300);
-    assert_eq!(headers[0].number, 0);
+    assert_eq!(headers[0].block_number, 0);
     let era_verifier = EraValidator::default();
     let epoch: Epoch = headers.try_into().unwrap();
     let result = era_verifier.validate_era(&epoch)?;

--- a/crates/header-accumulator/src/lib.rs
+++ b/crates/header-accumulator/src/lib.rs
@@ -8,8 +8,10 @@ mod epoch;
 mod era_validator;
 mod errors;
 mod inclusion_proof;
+mod types;
 
 pub use epoch::*;
 pub use era_validator::*;
 pub use errors::*;
 pub use inclusion_proof::*;
+pub use types::*;

--- a/crates/header-accumulator/src/types.rs
+++ b/crates/header-accumulator/src/types.rs
@@ -1,0 +1,83 @@
+// Copyright 2024-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+use alloy_primitives::{Uint, B256};
+use ethportal_api::{types::execution::accumulator::HeaderRecord, Header};
+use firehose_protos::{BlockHeader, EthBlock as Block};
+
+use crate::errors::EraValidateError;
+
+/// Extension of header with conversion traits
+///
+/// It's capable of converting to HeaderRecord to be used inside Epochs.
+/// It can also convert to firehose protos.
+/// You can extract the full header as an option
+#[derive(Clone)]
+pub struct ExtHeaderRecord {
+    /// Block hash
+    pub block_hash: B256,
+    /// Total difficulty
+    pub total_difficulty: Uint<256, 4>,
+    /// Block number
+    pub block_number: u64,
+    /// Full header
+    pub full_header: Option<Header>,
+}
+
+impl From<ExtHeaderRecord> for HeaderRecord {
+    fn from(
+        ExtHeaderRecord {
+            block_hash,
+            total_difficulty,
+            ..
+        }: ExtHeaderRecord,
+    ) -> Self {
+        HeaderRecord {
+            block_hash,
+            total_difficulty,
+        }
+    }
+}
+
+impl TryFrom<ExtHeaderRecord> for Header {
+    type Error = EraValidateError;
+
+    fn try_from(ext: ExtHeaderRecord) -> Result<Self, Self::Error> {
+        ext.full_header
+            .ok_or(EraValidateError::ExtHeaderRecordError(ext.block_number))
+    }
+}
+
+impl From<&ExtHeaderRecord> for HeaderRecord {
+    fn from(ext: &ExtHeaderRecord) -> Self {
+        HeaderRecord {
+            block_hash: ext.block_hash,
+            total_difficulty: ext.total_difficulty,
+        }
+    }
+}
+
+/// Decodes a [`ExtHeaderRecord`] from a [`Block`]. A [`BlockHeader`] must be present in the block,
+/// otherwise validating headers won't be possible
+impl TryFrom<&Block> for ExtHeaderRecord {
+    type Error = EraValidateError;
+
+    fn try_from(block: &Block) -> Result<Self, Self::Error> {
+        let header: &BlockHeader = block
+            .header
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+
+        let total_difficulty = header
+            .total_difficulty
+            .as_ref()
+            .ok_or(EraValidateError::HeaderDecodeError)?;
+
+        Ok(ExtHeaderRecord {
+            block_number: block.number,
+            block_hash: B256::from_slice(&block.hash),
+            total_difficulty: Uint::from_be_slice(total_difficulty.bytes.as_slice()),
+            full_header: Some(block.try_into()?),
+        })
+    }
+}

--- a/crates/vee/README.md
+++ b/crates/vee/README.md
@@ -1,20 +1,17 @@
 # Vee
 
-Verifiable Extraction for Blockchain.
+Verifiable Extraction for Blockchain data.
 
-This crate exposes the interfaces from other crates in ve.
+This crate exposes the interfaces from other crates in veemon.
 
 ### Verifiabilty for Ethereum
 ![Full path of proofs diagram](./assets/diagram.svg)
 
+Events recorded in transaction receipt logs are useful for analysis of blockchain data. Ensuring that the receipts recorded in extracted blocks accurately reflect the chain's history is critical for developers. veemon provides the capability to generate inclusion proofs for receipts against the `receipts_root` in the block header as well as to reconstruct the `receipts_root` for validation.
 
-In order for verifiable extraction to work, it depends partially on [portal network accumualtors](https://github.com/ethereum/portal-accumulators)
-which consists of the header accumulators for pre-merge, post-merge & pre-capella.
-
-For post-capella, it relies on the 
+veemon also provides implementations for verification of the block itself against the history of the blockchain. Verifying inclusion of a block in the Ethereum history relies on [Ethereum Portal Network Accumulators](https://github.com/ethereum/portal-accumulators)
+which use Header Accumulators built on historical block hash information for pre-Merge, post-Merge & pre-Capella Ethereum blocks. Post-Capella Accumulators rely on the 
 `HistoricalSummary` which is extracted from the `HeadState` of the beacon chain, and the associated beacon blocks as well. 
-
-As seen on the diagram above, VE also has implementations for the constructing parts of blocks. Since most of the interesting data is on events, it is possible to generate proofs for receipts against the `receipts_root`, then proofs that the `receipts_root` is valid givne the block, and then the proofs that the blocks are valid within the canonicalness of the chain.
 
 
 ## Examples
@@ -144,16 +141,15 @@ fn main() -> Result<(), EraValidateError> {
 
 ### Other available examples
 
-Other usage examples are available in the examples folder. These depend on  [ve-assets](https://github.com/semiotic-ai/ve-assets) to run. Choose each example carefully given the .dbin or .parquet file, because the blocks have to be within the specific block number range for it to work. These usage examples are:
+Other examples and tests in veemon depend on  [ve-assets](https://github.com/semiotic-ai/ve-assets) to run. Choose each example carefully given the .dbin or .parquet file, because the blocks have to be within the specific block number range for it to work. These usage examples are:
 
 1. Convert parquet data structure into the same `BlockHeader` 
-2. Build receipt proofa gainst receipts
+2. Build receipt proof against receipts
 3. Build proof that `receipt_root` is correct against `receipt`.
-4. Build proof of pre-merge and pre-capella block against header accumulaors.
-5. Build proof of psot-capella blocks given beacon blocks and Ethereum head state
+4. Build proof of pre-Merge and pre-Capella block against Header Accumulaors.
+5. Build proof of post-Capella blocks given beacon blocks and Ethereum head state
 
 ## Testing
 
-Some testing assets were stored in [ve-assets](https://github.com/semiotic-ai/ve-assets)
-. These include parquet file block headers and .dbin files extracted from Firehose. Part of these are necessary for some tests, but they are heavy so most of them are stored in another repo.
+Some testing assets were stored in [ve-assets](https://github.com/semiotic-ai/ve-assets). These include parquet file block headers and .dbin files extracted from Firehose. Part of these are necessary for some tests, but they are heavy so most of them are stored in another repo.
 

--- a/crates/vee/examples/verify_blocks_from_dbin.rs
+++ b/crates/vee/examples/verify_blocks_from_dbin.rs
@@ -1,0 +1,100 @@
+// Copyright 2025-, Semiotic AI, Inc.
+// SPDX-License-Identifier: Apache-2.0
+
+//! Example docs
+//! In this example, we verify a block derived from a StreamingFast .dbin file.
+//! We are verifying block number 99 from pre-Merge Ethereum as an example.
+
+use std::{fs::File, io::BufReader};
+use tree_hash::Hash256;
+use vee::{read_blocks_from_reader, AnyBlock, Compression, Epoch, EraValidator, ExtHeaderRecord};
+
+fn main() {
+    // Path to .dbin file containing block to verify. This is our "extracted"
+    // data. Suppose we need some information contained in a specific block
+    // which we need to verify is correct.
+    // First we parse the file into blocks.
+    // These example dbin files contain 100 blocks each. Here we are using
+    // the last block in our example file 0000000000.dbin.
+    let path = "../ve-assets/dbin/pre-merge/0000000000.dbin";
+    let buf_reader = BufReader::new(File::open(path).unwrap());
+    let blocks = read_blocks_from_reader(buf_reader, Compression::None).unwrap();
+    let any_block = blocks.last().unwrap();
+    let block = any_block.clone().try_into_eth_block().unwrap();
+
+    // `read_blocks_from_reader` includes a check that the contents of the
+    // blocks in the file (receipts, transactions, and blockhash) are valid.
+    // If the file was decoded successfully, the contents were verified as
+    // part of that process. Here, we perform the verification again separately
+    // to demonstrate what is happening.
+
+    // `receipt_root_is_verified` reconstructs the receipts Merkle trie using the receipts
+    // recorded in the block. The root of the trie is then compared against the receipts root hash
+    // recorded in the block header. If they match, then the receipt contents of the
+    // block are consistent with the commitment recorded in the block header.
+    assert!(block.receipt_root_is_verified());
+    // `transaction_root_is_verified` reconstructs the transactions Merkle trie using the transaction traces
+    // recorded in the block. The root of the trie is then compared against the transactions
+    // root hash recorded in the block header. If they match, then the transaction contents of the
+    // block are consistent with the commitment recorded in the block header.
+    assert!(block.transaction_root_is_verified());
+    // `block_hash_is_verified` calculates the block hash using information from the block header,
+    // including the receipts root and the transactions root. The calculated block hash is then
+    // compared against the block hash recorded in the block header. If they match, then
+    // the contents of the block header incorporated in the hash are consistent with
+    // the hash recorded in the header. The block hash can be used to prove inclusion
+    // of the block in the chain's history.
+    assert!(block.block_hash_is_verified());
+    println!("Block contents validated successfully.");
+
+    // Next, show that the block (represented by its block hash) was included in
+    // the chain's history, i.e., the block is valid compared against the
+    // Ethereum ledger.
+    // Our trusted source here is the `PreMergeAccumulator` maintained by
+    // Ethereum Portal Network. For each era (8192 blocks) in the pre-Merge
+    // Ethereum chain, a Merkle tree is constructed with the block hashes of
+    // the era at the leaves. The root hash of the tree is recorded
+    // in the accumulator. We can reconstruct the tree for a given era and
+    // check the calculated root against the recorded value.
+
+    // To reconstruct the tree for the era containing the block in question,
+    // we need all block hashes from the era. For this example, we obtain
+    // the blocks from more StreamingFast dbin files extracted using Firehose.
+    let mut headers: Vec<ExtHeaderRecord> = Vec::new();
+    for number in (0..=8200).step_by(100) {
+        let file_name = format!("../ve-assets/dbin/pre-merge/{:010}.dbin", number);
+        let reader = BufReader::new(File::open(file_name.clone()).unwrap());
+        let blocks = read_blocks_from_reader(reader, Compression::None).unwrap();
+        let successful_headers = blocks
+            .iter()
+            .filter_map(|block| {
+                if let AnyBlock::Evm(eth_block) = block {
+                    ExtHeaderRecord::try_from(eth_block).ok()
+                } else {
+                    // Note, Header Accumulators are currently only supported
+                    // for Ethereum type blocks.
+                    println!("File contains non-Ethereum Block: {}", file_name);
+                    None
+                }
+            })
+            .collect::<Vec<_>>();
+        headers.extend(successful_headers);
+    }
+    // Arrange block headers in order and determine the era number in which they belong.
+    let era: Epoch = headers.try_into().unwrap();
+    // `EraValidator` struct containing a historical record of Merkle tree roots
+    // from the trusted `PreMergeAccumulator`.
+    let era_verifier = EraValidator::default();
+    // `validate_era` calculates the root of the Merkle tree with this era's
+    // block hashes at the leaves. The method includes a check that the calculated
+    // value matches that in the `EraValidator` for this era.
+    let result = era_verifier.validate_era(&era).unwrap();
+    // Here, we compare the historical record with the calculated value separately
+    // to show what is happening.
+    let expected = Hash256::new([
+        94, 193, 255, 184, 195, 177, 70, 244, 38, 6, 199, 76, 237, 151, 61, 193, 110, 197, 161, 7,
+        192, 52, 88, 88, 195, 67, 252, 148, 120, 11, 66, 24,
+    ]);
+    assert_eq!(result, expected);
+    println!("Extracted blocks match historical record.")
+}


### PR DESCRIPTION
This commit adds an example illustrating end-to-end verification of a pre-Merge EVM block starting with a StreamingFast Firehose Flat file, verifying the content of the example block, then loading an era's worth of blocks (also from flat files) to reconstruct the root for the Header Accumulator corresponding to this era.