### PR TITLE
ci(release): target main for release

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -145,5 +145,5 @@ jobs:
             --repo-url=semiotic-ai/veemon \
             --token=${{ secrets.GITHUB_TOKEN }} \
             --manifest-file .release-please-manifest.json \
-            --target-branch=${{ github.head_ref }} \
+            --target-branch=${{ github.base_ref }} \
             --dry-run


### PR DESCRIPTION
This hopefully fixes an issue when we have PRs from forks where our workflow is looking for release config on the fork branch rather than on the base (`main`).

Fixes a CI "edge case" that was people contributing from a fork of the repo.