### PR TITLE
Amp integration

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ resolver = "2"
 
 [workspace.dependencies]
 alloy-rlp = "0.3.12"
-alloy-consensus = "^1.2"
+alloy-consensus = "^1.2" # use old version to match amp
 alloy-eip2930 = "0.2.3"
-alloy-primitives = "^1.4"
+alloy-primitives = "^1.4" # use old version to match amp
 anyhow = "1.0.100"
 arbitrum-ve = { path = "crates/arbitrum-ve" }
 era-validation = { path = "crates/era-validation" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,9 +18,9 @@ resolver = "2"
 
 [workspace.dependencies]
 alloy-rlp = "0.3.12"
-alloy-consensus = "1.3.0"
+alloy-consensus = "^1.2"
 alloy-eip2930 = "0.2.3"
-alloy-primitives = "1.5.2"
+alloy-primitives = "^1.4"
 anyhow = "1.0.100"
 arbitrum-ve = { path = "crates/arbitrum-ve" }
 era-validation = { path = "crates/era-validation" }

--- a/crates/era-validation/Cargo.toml
+++ b/crates/era-validation/Cargo.toml
@@ -9,6 +9,10 @@ license = "Apache-2.0"
 description = "multi-chain block era validation for ethereum and solana"
 authors = ["Semiotic AI <info@semiotic.ai>"]
 
+[features]
+default = ["firehose"]
+firehose = ["dep:firehose-protos"]
+
 [dependencies]
 # foundation
 validation.workspace = true
@@ -17,7 +21,7 @@ validation.workspace = true
 alloy-consensus.workspace = true
 alloy-primitives.workspace = true
 ethportal-api.workspace = true
-firehose-protos.workspace = true
+firehose-protos = { workspace = true, optional = true }
 tree_hash.workspace = true
 
 # lighthouse types (for beacon chain)

--- a/crates/era-validation/Cargo.toml
+++ b/crates/era-validation/Cargo.toml
@@ -10,8 +10,10 @@ description = "multi-chain block era validation for ethereum and solana"
 authors = ["Semiotic AI <info@semiotic.ai>"]
 
 [features]
-default = ["firehose"]
+default = ["firehose", "beacon", "solana"]
 firehose = ["dep:firehose-protos"]
+beacon = ["dep:types", "dep:merkle_proof"]
+solana = ["dep:merkle_proof"]
 
 [dependencies]
 # foundation
@@ -24,9 +26,9 @@ ethportal-api.workspace = true
 firehose-protos = { workspace = true, optional = true }
 tree_hash.workspace = true
 
-# lighthouse types (for beacon chain)
-types.workspace = true
-merkle_proof.workspace = true
+# lighthouse types (for beacon chain) - optional
+types = { workspace = true, optional = true }
+merkle_proof = { workspace = true, optional = true }
 primitive-types.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/era-validation/src/error.rs
+++ b/crates/era-validation/src/error.rs
@@ -1,6 +1,7 @@
 // SPDX-FileCopyrightText: 2024- Semiotic AI, Inc.
 // SPDX-License-Identifier: Apache-2.0
 
+#[cfg(feature = "firehose")]
 use firehose_protos::ProtosError;
 use primitive_types::H256;
 
@@ -69,6 +70,7 @@ pub enum EraValidationError {
     ProofValidationFailure,
 
     // Header/Block errors
+    #[cfg(feature = "firehose")]
     #[error("error decoding header from flat files: {0}")]
     HeaderDecode(#[source] ProtosError),
 
@@ -171,6 +173,7 @@ pub enum SolanaValidatorError {
     },
 }
 
+#[cfg(feature = "firehose")]
 impl From<ProtosError> for EraValidationError {
     fn from(error: ProtosError) -> Self {
         EraValidationError::HeaderDecode(error)

--- a/crates/era-validation/src/error.rs
+++ b/crates/era-validation/src/error.rs
@@ -5,7 +5,9 @@
 use firehose_protos::ProtosError;
 use primitive_types::H256;
 
-use crate::types::{BlockNumber, EpochNumber, EraNumber, SlotNumber};
+use crate::types::{BlockNumber, EpochNumber};
+#[cfg(feature = "beacon")]
+use crate::types::{EraNumber, SlotNumber};
 
 /// Unified era validation error type for all blockchain eras and chains
 #[derive(thiserror::Error, Debug)]
@@ -15,14 +17,17 @@ pub enum EraValidationError {
     EthereumPreMerge(#[from] EthereumPreMergeError),
 
     // Ethereum Post-Merge errors
+    #[cfg(feature = "beacon")]
     #[error("ethereum post-merge validation failed: {0}")]
     EthereumPostMerge(#[from] EthereumPostMergeError),
 
     // Ethereum Post-Capella errors
+    #[cfg(feature = "beacon")]
     #[error("ethereum post-capella validation failed: {0}")]
     EthereumPostCapella(#[from] EthereumPostCapellaError),
 
     // Solana errors
+    #[cfg(feature = "solana")]
     #[error("solana validation failed: {0}")]
     Solana(#[from] SolanaValidatorError),
 
@@ -114,6 +119,7 @@ pub enum EthereumPreMergeError {
 }
 
 /// Common errors for Ethereum PoS eras (post-merge and post-Capella)
+#[cfg(feature = "beacon")]
 #[derive(thiserror::Error, Debug, Clone)]
 pub enum EthereumPosEraError {
     #[error("number of execution block hashes must match the number of beacon blocks")]
@@ -140,6 +146,7 @@ pub enum EthereumPosEraError {
 }
 
 /// Ethereum post-merge (pre-Capella) specific errors
+#[cfg(feature = "beacon")]
 #[derive(thiserror::Error, Debug)]
 pub enum EthereumPostMergeError {
     #[error(transparent)]
@@ -147,6 +154,7 @@ pub enum EthereumPostMergeError {
 }
 
 /// Ethereum post-Capella specific errors
+#[cfg(feature = "beacon")]
 #[derive(thiserror::Error, Debug)]
 pub enum EthereumPostCapellaError {
     #[error(transparent)]
@@ -154,6 +162,7 @@ pub enum EthereumPostCapellaError {
 }
 
 /// Solana specific errors
+#[cfg(feature = "solana")]
 #[derive(thiserror::Error, Debug)]
 pub enum SolanaValidatorError {
     #[error("number of execution block hashes must match the epoch length")]

--- a/crates/era-validation/src/ethereum/mod.rs
+++ b/crates/era-validation/src/ethereum/mod.rs
@@ -3,15 +3,20 @@
 
 //! ethereum block era validation across all eras
 
+#[cfg(feature = "beacon")]
 mod common;
+#[cfg(feature = "beacon")]
 pub mod post_capella;
+#[cfg(feature = "beacon")]
 pub mod post_merge;
 pub mod pre_merge;
 pub mod proof;
 pub mod types;
 
 // re-export public types
+#[cfg(feature = "beacon")]
 pub use post_capella::EthereumPostCapellaValidator;
+#[cfg(feature = "beacon")]
 pub use post_merge::EthereumPostMergeValidator;
 pub use pre_merge::EthereumPreMergeValidator;
 pub use proof::{

--- a/crates/era-validation/src/ethereum/types.rs
+++ b/crates/era-validation/src/ethereum/types.rs
@@ -6,6 +6,7 @@ use std::array::IntoIter;
 use alloy_consensus::Header;
 use alloy_primitives::{Uint, B256};
 use ethportal_api::types::execution::accumulator::{EpochAccumulator, HeaderRecord};
+#[cfg(feature = "firehose")]
 use firehose_protos::{BlockHeader, EthBlock as Block, ProtosError};
 
 use crate::error::EraValidationError;
@@ -133,6 +134,34 @@ pub struct ExtHeaderRecord {
     pub full_header: Option<Header>,
 }
 
+impl ExtHeaderRecord {
+    /// Creates a new ExtHeaderRecord from alloy-consensus Header
+    ///
+    /// This constructor is useful when you're not using firehose and want to
+    /// create ExtHeaderRecords directly from alloy types.
+    pub fn new(header: Header, total_difficulty: Uint<256, 4>) -> Self {
+        Self {
+            block_hash: header.hash_slow(),
+            total_difficulty,
+            block_number: BlockNumber(header.number),
+            full_header: Some(header),
+        }
+    }
+
+    /// Creates a new ExtHeaderRecord with only the hash and total difficulty
+    ///
+    /// This is useful when you only need to validate the epoch accumulator
+    /// but don't need the full header data.
+    pub fn new_minimal(block_hash: B256, total_difficulty: Uint<256, 4>, block_number: BlockNumber) -> Self {
+        Self {
+            block_hash,
+            total_difficulty,
+            block_number,
+            full_header: None,
+        }
+    }
+}
+
 impl From<ExtHeaderRecord> for HeaderRecord {
     fn from(
         ExtHeaderRecord {
@@ -168,6 +197,7 @@ impl From<&ExtHeaderRecord> for HeaderRecord {
 
 /// decodes a [`ExtHeaderRecord`] from a [`Block`]. a [`BlockHeader`] must be present in the block,
 /// otherwise validating headers won't be possible
+#[cfg(feature = "firehose")]
 impl TryFrom<&Block> for ExtHeaderRecord {
     type Error = EraValidationError;
 

--- a/crates/era-validation/src/ethereum/types.rs
+++ b/crates/era-validation/src/ethereum/types.rs
@@ -152,7 +152,11 @@ impl ExtHeaderRecord {
     ///
     /// This is useful when you only need to validate the epoch accumulator
     /// but don't need the full header data.
-    pub fn new_minimal(block_hash: B256, total_difficulty: Uint<256, 4>, block_number: BlockNumber) -> Self {
+    pub fn new_minimal(
+        block_hash: B256,
+        total_difficulty: Uint<256, 4>,
+        block_number: BlockNumber,
+    ) -> Self {
         Self {
             block_hash,
             total_difficulty,

--- a/crates/era-validation/src/lib.rs
+++ b/crates/era-validation/src/lib.rs
@@ -5,6 +5,12 @@
 //!
 //! multi-chain block and header era validation library.
 //!
+//! ## Features
+//!
+//! - **firehose** (default): Enables support for converting from firehose-protos Block types
+//!   to ExtHeaderRecord. Disable with `default-features = false` to avoid pulling in reth
+//!   dependencies.
+//!
 //! ## ethereum era validation
 //!
 //! ethereum has three distinct validation eras:
@@ -13,7 +19,7 @@
 //! - **post-merge (pos)**: blocks 15,537,394-17,034,869 - validated against HistoricalRoots
 //! - **post-capella (pos)**: blocks 17,034,870+ - validated against HistoricalSummaries
 //!
-//! ### quick start
+//! ### quick start (with firehose)
 //!
 //! ```rust,ignore
 //! use era_validation::ethereum::{EthereumPreMergeValidator, Epoch};
@@ -21,6 +27,30 @@
 //!
 //! // create validator with default historical roots
 //! let validator = EthereumPreMergeValidator::default();
+//!
+//! // validate an epoch
+//! let epoch: Epoch = headers.try_into()?;
+//! let result = validator.validate_era((epoch.number(), epoch.into()))?;
+//! ```
+//!
+//! ### quick start (without firehose - using alloy types)
+//!
+//! ```rust,ignore
+//! use era_validation::ethereum::{EthereumPreMergeValidator, Epoch, ExtHeaderRecord};
+//! use era_validation::traits::EraValidationContext;
+//! use alloy_consensus::Header;
+//! use alloy_primitives::Uint;
+//!
+//! // create validator with default historical roots
+//! let validator = EthereumPreMergeValidator::default();
+//!
+//! // convert alloy Headers to ExtHeaderRecords
+//! let headers: Vec<ExtHeaderRecord> = alloy_headers
+//!     .into_iter()
+//!     .map(|(header, total_difficulty): (Header, Uint<256, 4>)| {
+//!         ExtHeaderRecord::new(header, total_difficulty)
+//!     })
+//!     .collect();
 //!
 //! // validate an epoch
 //! let epoch: Epoch = headers.try_into()?;

--- a/crates/era-validation/src/lib.rs
+++ b/crates/era-validation/src/lib.rs
@@ -10,6 +10,18 @@
 //! - **firehose** (default): Enables support for converting from firehose-protos Block types
 //!   to ExtHeaderRecord. Disable with `default-features = false` to avoid pulling in reth
 //!   dependencies.
+//! - **beacon** (default): Enables post-merge and post-Capella Ethereum validation. Requires
+//!   lighthouse types. Disable to avoid libsqlite3-sys version conflicts.
+//! - **solana** (default): Enables Solana era validation. Requires lighthouse's merkle_proof.
+//!
+//! ### For amp-internal integration (avoiding reth and sqlite conflicts)
+//!
+//! ```toml
+//! [dependencies]
+//! era-validation = { git = "https://github.com/semiotic-ai/veemon", branch = "amp-integration", default-features = false }
+//! ```
+//!
+//! This gives you pre-merge Ethereum validation with alloy types only, no reth or lighthouse dependencies.
 //!
 //! ## ethereum era validation
 //!
@@ -69,6 +81,7 @@
 
 pub mod error;
 pub mod ethereum;
+#[cfg(feature = "solana")]
 pub mod solana;
 pub mod traits;
 pub mod types;
@@ -83,21 +96,28 @@ pub use types::{BlockNumber, EpochNumber, EraNumber, SlotNumber};
 // re-export ethereum types and validators
 pub use ethereum::{
     generate_inclusion_proof, generate_inclusion_proofs, verify_inclusion_proof,
-    verify_inclusion_proofs, Epoch, EthereumPostCapellaValidator, EthereumPostMergeValidator,
-    EthereumPreMergeValidator, ExtHeaderRecord, HeaderWithProof, InclusionProof,
+    verify_inclusion_proofs, Epoch, EthereumPreMergeValidator, ExtHeaderRecord, HeaderWithProof,
+    InclusionProof,
 };
 
+#[cfg(feature = "beacon")]
+pub use ethereum::{EthereumPostCapellaValidator, EthereumPostMergeValidator};
+
 // re-export solana types and validators
+#[cfg(feature = "solana")]
 pub use solana::SolanaValidator;
 
 // re-export generic validator
 pub use validator::EraValidatorGeneric;
 
 // re-export errors
-pub use error::{
-    EraValidationError, EthereumPostCapellaError, EthereumPostMergeError, EthereumPreMergeError,
-    SolanaValidatorError,
-};
+pub use error::{EraValidationError, EthereumPreMergeError};
+
+#[cfg(feature = "beacon")]
+pub use error::{EthereumPostCapellaError, EthereumPostMergeError};
+
+#[cfg(feature = "solana")]
+pub use error::SolanaValidatorError;
 
 // re-export commonly used validation types
 pub use validation::header_validator::HeaderValidator;


### PR DESCRIPTION
Gates some features behind cfg so it doesn't conflict with Amp versions.
Also allows alloy 1.2+ to enable compatibility with current version used by Amp.

I don't think right now we have any reason to not have alloy on 1.4, because since it is only integrated into Amp, there is no problem of breaking changes. I'm thinking if it benefits this repo to have a "amp-integration" branch and just use that branch in Amp too,...