### PR TITLE
feat: turn firehose-protos optional

### DIFF
--- a/crates/vee/Cargo.toml
+++ b/crates/vee/Cargo.toml
@@ -10,9 +10,13 @@ edition = "2021"
 path = "src/lib.rs"
 name = "vee"
 
+[features]
+default = []
+firehose = ["dep:firehose-protos", "dep:decoder"]
+
 [dependencies]
-firehose-protos.workspace = true
-decoder.workspace = true
+firehose-protos = { workspace = true, optional = true }
+decoder = { workspace = true, optional = true }
 era-validation.workspace = true
 header-accumulator.workspace = true
 arbitrum-ve.workspace = true

--- a/crates/vee/src/lib.rs
+++ b/crates/vee/src/lib.rs
@@ -6,9 +6,11 @@
 
 // 🚀✨ Main Re-exports ✨🚀
 
+#[cfg(feature = "firehose")]
 #[doc(inline)]
 pub use firehose_protos as protos;
 
+#[cfg(feature = "firehose")]
 #[doc(inline)]
 pub use flat_files_decoder as decoder;
 
@@ -33,5 +35,9 @@ pub use era_validation::EraValidationContext;
 pub use accumulator::*;
 
 pub use arbitrum_ve::*;
+
+#[cfg(feature = "firehose")]
 pub use decoder::*;
+
+#[cfg(feature = "firehose")]
 pub use protos::*;


### PR DESCRIPTION
Turns `firehose-protos` optional. They are not necessary in amp, and they have conflicting dependencies.